### PR TITLE
Cache the latest screen and use it on scopedStore not to replay initial screen

### DIFF
--- a/Sources/TCACoordinators/TCARouter/TCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter.swift
@@ -22,9 +22,13 @@ public struct TCARouter<
 
   func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
     let id = identifier(screen, index)
+    var screen = screen
     return store.scope(
-        state: { routes($0)[safe: index]?.screen ?? screen },
-        action: { action(id, $0) }
+      state: {
+        screen = routes($0)[safe: index]?.screen ?? screen
+        return screen
+      },
+      action: { action(id, $0) }
     )
   }
 

--- a/TCACoordinatorsExample/TCACoordinatorsExample/TCACoordinatorsExampleApp.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/TCACoordinatorsExampleApp.swift
@@ -23,27 +23,25 @@ struct MainTabCoordinatorView: View {
   let store: Store<MainTabCoordinatorState, MainTabCoordinatorAction>
 
   var body: some View {
-    WithViewStore(store) { _ in
-      TabView {
-        IndexedCoordinatorView(
-          store: store.scope(
-            state: \MainTabCoordinatorState.indexed,
-            action: MainTabCoordinatorAction.indexed
-          )
-        ).tabItem { Text("Indexed") }
-        IdentifiedCoordinatorView(
-          store: store.scope(
-            state: \MainTabCoordinatorState.identified,
-            action: MainTabCoordinatorAction.identified
-          )
-        ).tabItem { Text("Identified") }
-        AppCoordinatorView(
-          store: store.scope(
-            state: \MainTabCoordinatorState.app,
-            action: MainTabCoordinatorAction.app
-          )
-        ).tabItem { Text("App") }
-      }
+    TabView {
+      IndexedCoordinatorView(
+        store: store.scope(
+          state: \MainTabCoordinatorState.indexed,
+          action: MainTabCoordinatorAction.indexed
+        )
+      ).tabItem { Text("Indexed") }
+      IdentifiedCoordinatorView(
+        store: store.scope(
+          state: \MainTabCoordinatorState.identified,
+          action: MainTabCoordinatorAction.identified
+        )
+      ).tabItem { Text("Identified") }
+      AppCoordinatorView(
+        store: store.scope(
+          state: \MainTabCoordinatorState.app,
+          action: MainTabCoordinatorAction.app
+        )
+      ).tabItem { Text("App") }
     }
   }
 }


### PR DESCRIPTION
Fixes #26 

The idea is from https://github.com/pointfreeco/swift-composable-architecture/pull/667