### PR TITLE
Fixes for TCA's ReducerProtocol

### DIFF
--- a/Sources/TCACoordinators/ReducerExtensions/Reducer+forEachIdentifiedRoute.swift
+++ b/Sources/TCACoordinators/ReducerExtensions/Reducer+forEachIdentifiedRoute.swift
@@ -85,7 +85,7 @@ extension Reducer {
   func updateScreensOnInteraction<Routes>(
     updateRoutes: CasePath<Action, Routes>,
     state toLocalState: WritableKeyPath<State, Routes>
-  ) -> Reducer {
+  ) -> Self {
     return self.combined(with: Reducer { state, action, environment in
       if let routes = updateRoutes.extract(from: action) {
         state[keyPath: toLocalState] = routes

--- a/Sources/TCACoordinators/ReducerExtensions/Reducer+tagging.swift
+++ b/Sources/TCACoordinators/ReducerExtensions/Reducer+tagging.swift
@@ -14,7 +14,7 @@ extension Reducer {
   func tagRouteEffectsForCancellation<RouteAction, CoordinatorID: Hashable, RouteID: Hashable>(
     coordinatorId: CoordinatorID,
     routeAction: CasePath<Action, (RouteID, RouteAction)>
-  ) -> Reducer {
+  ) -> Self {
     return Reducer { state, action, environment in
       let effect = self.run(&state, action, environment)
 
@@ -36,7 +36,7 @@ extension Reducer {
     coordinatorId: CoordinatorID,
     routes: @escaping (State) -> C,
     getIdentifier: @escaping (C.Element, C.Index) -> RouteID
-  ) -> Reducer
+  ) -> Self
   {
     return Reducer { state, action, environment in
       let preRoutes = routes(state)

--- a/Sources/TCACoordinators/ReducerExtensions/Reducer+withRouteReducer.swift
+++ b/Sources/TCACoordinators/ReducerExtensions/Reducer+withRouteReducer.swift
@@ -13,8 +13,8 @@ public extension Reducer where State: IndexedRouterState, Action: IndexedRouterA
   /// - Returns: The new reducer.
   func withRouteReducer(
     cancelEffectsOnDismiss: Bool = true,
-    _ routeReducer: Reducer
-  ) -> Reducer {
+    _ routeReducer: Self
+  ) -> Self {
     self.withRouteReducer(
       routes: \State.routes,
       routeAction: /Action.routeAction,
@@ -35,8 +35,8 @@ public extension Reducer where State: IdentifiedRouterState, Action: IdentifiedR
   /// - Returns: The new reducer.
   func withRouteReducer(
     cancelEffectsOnDismiss: Bool = true,
-    _ routeReducer: Reducer
-  ) -> Reducer {
+    _ routeReducer: Self
+  ) -> Self {
     self.withRouteReducer(
       routes: \State.routes,
       routeAction: /Action.routeAction,
@@ -62,8 +62,8 @@ public extension Reducer {
     routeAction: CasePath<Action, (RouteID, ScreenAction)>,
     coordinatorIdForCancellation: CoordinatorID?,
     getIdentifier: @escaping (C.Element, C.Index) -> RouteID,
-    routeReducer: Reducer
-  ) -> Reducer
+    routeReducer: Self
+  ) -> Self
   {
     guard let coordinatorId = coordinatorIdForCancellation else {
       return self.combined(with: routeReducer)


### PR DESCRIPTION
TCA is refactoring onto a protocol in the future, so there are a few issues with using `Reducer` directly now. This PR fixes the issues seen so far by switching to `Self`, which should work with old and new TCA.

There are other deprecation warnings that I didn't fix, nor did I refactor anything onto the new protocol.