### PR TITLE
Ensure Router's binding has access to latest state

### DIFF
--- a/Sources/TCACoordinators/TCARouter/TCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter.swift
@@ -21,14 +21,16 @@ public struct TCARouter<
   @ViewBuilder var screenContent: (Store<Screen, ScreenAction>) -> ScreenContent
 
   func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
-    let id = identifier(screen, index)
     var screen = screen
     return store.scope(
       state: {
         screen = routes($0)[safe: index]?.screen ?? screen
         return screen
       },
-      action: { action(id, $0) }
+      action: {
+        let id = identifier(screen, index)
+        return action(id, $0)
+      }
     )
   }
 

--- a/Sources/TCACoordinators/TCARouter/TCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter.swift
@@ -35,7 +35,7 @@ public struct TCARouter<
   public var body: some View {
     WithViewStore(store, removeDuplicates: { routes($0).map(\.style) == routes($1).map(\.style) }) { viewStore in
       Router(
-        viewStore.binding(
+        ViewStore(store).binding(
           get: routes,
           send: updateRoutes
         ),


### PR DESCRIPTION
This PR:

- Ensures `Router`'s binding has access to the latest state, fixing #34. Previously it would miss state updates that were ignored by the `removeDuplicates` closure.

Thanks to @salqueng for the fix!