### PR TITLE
Update for 0.43 Breakage

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/TCACoordinators.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/TCACoordinators.xcscheme
@@ -22,29 +22,15 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "TCACoordinatorsTests"
                BuildableName = "TCACoordinatorsTests"
                BlueprintName = "TCACoordinatorsTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "TCACoordinatorsExamples"
-               BuildableName = "TCACoordinatorsExamples"
-               BlueprintName = "TCACoordinatorsExamples"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,17 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "6bde3b0063ba8e7537b43744948535ca7e9e0dad",
-          "version": "0.5.2"
+          "revision": "aa3e575929f2bcc5bad012bd2575eae716cbcdf7",
+          "version": "0.8.0"
         }
       },
       {
         "package": "FlowStacks",
-        "repositoryURL": "https://www.github.com/johnpatrickmorgan/FlowStacks",
+        "repositoryURL": "https://github.com/johnpatrickmorgan/FlowStacks",
         "state": {
           "branch": null,
-          "revision": "4ed960a0ad8bb1623d18eb31a3fc483410555f73",
-          "version": "0.0.13"
+          "revision": "8d1bc577fcab0c09d599f1f2f6747db2d15f84f4",
+          "version": "0.3.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {
           "branch": null,
-          "revision": "d226d167bd4a68b51e352af5655c92bce8ee0463",
-          "version": "0.7.0"
+          "revision": "15bba50ebf3a2065388c8d12210debe4f6ada202",
+          "version": "0.10.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "07e47b1e93e5a1e0ef0c50fcb2d6739fb6be4003",
-          "version": "1.0.0"
+          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
+          "version": "1.0.3"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture",
         "state": {
           "branch": null,
-          "revision": "a1aac6cfd654051d0ab5e626462afff36c399219",
-          "version": "0.27.1"
+          "revision": "5bd450a8ac6a802f82d485bac219cbfacffa69fb",
+          "version": "0.43.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
           "branch": null,
-          "revision": "1a2947d25d43e295c6f5e83f54696d590620b364",
-          "version": "0.1.3"
+          "revision": "819d9d370cd721c9d87671e29d947279292e4541",
+          "version": "0.6.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
         "state": {
           "branch": null,
-          "revision": "c8e6a40209650ab619853cd4ce89a0aa51792754",
-          "version": "0.3.0"
+          "revision": "bfb0d43e75a15b6dfac770bf33479e8393884a36",
+          "version": "0.4.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
-          "version": "0.2.1"
+          "revision": "30314f1ece684dd60679d598a9b89107557b67d9",
+          "version": "0.4.1"
         }
       }
     ]

--- a/Sources/TCACoordinators/Effect+routeWithDelaysIfUnsupported.swift
+++ b/Sources/TCACoordinators/Effect+routeWithDelaysIfUnsupported.swift
@@ -15,7 +15,7 @@ public extension Effect where Output: IndexedRouterAction, Failure == Never {
   /// - Parameter transform: A closure transforming the routes into their new state.
   /// - Returns: An Effect stream of actions with incremental updates to routes over time. If the proposed change is supported
   ///   within a single update, the Effect stream will include only one element.
-  static func routeWithDelaysIfUnsupported(_ routes: [Route<Output.Screen>], _ transform: (inout [Route<Output.Screen>]) -> Void) -> Effect {
+  static func routeWithDelaysIfUnsupported(_ routes: [Route<Output.Screen>], _ transform: (inout [Route<Output.Screen>]) -> Void) -> Self {
     var transformedRoutes = routes
     transform(&transformedRoutes)
     let steps = RouteSteps.calculateSteps(from: routes, to: transformedRoutes)
@@ -36,7 +36,7 @@ public extension Effect where Output: IdentifiedRouterAction, Failure == Never {
   /// - Parameter transform: A closure transforming the routes into their new state.
   /// - Returns: An Effect stream of actions with incremental updates to routes over time. If the proposed change is supported
   ///   within a single update, the Effect stream will include only one element.
-  static func routeWithDelaysIfUnsupported(_ routes: IdentifiedArrayOf<Route<Output.Screen>>, _ transform: (inout IdentifiedArrayOf<Route<Output.Screen>>) -> Void) -> Effect {
+  static func routeWithDelaysIfUnsupported(_ routes: IdentifiedArrayOf<Route<Output.Screen>>, _ transform: (inout IdentifiedArrayOf<Route<Output.Screen>>) -> Void) -> Self {
     var transformedRoutes = routes
     transform(&transformedRoutes)
     let steps = RouteSteps.calculateSteps(from: Array(routes), to: Array(transformedRoutes))

--- a/Tests/TCACoordinatorsTests/TCACoordinatorsTests.swift
+++ b/Tests/TCACoordinatorsTests/TCACoordinatorsTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import TCACoordinators
-import TCACoordinatorsExample
 
 final class TCACoordinatorsTests: XCTestCase {
   


### PR DESCRIPTION
TCA 0.43 changes the definition of `Effect`. This PR updates a couple usage sites to replace `Effect` with `Self` to handle that change.

This PR also performs a bit of project cleanup by removing a scheme reference to the examples, which was causing a build failure.

There are some other cleanups that are possible, such as:

* Requiring newer versions of the dependencies in the Package. 
* Fixing warnings.
* Adopting the new `ReducerProtocol`, as the old `Reducer` will be going away.

Those are not done in this PR.