### PR TITLE
Documentation: Prefer `Scope` over `ifCaseLet` when all logic is mutually exclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,15 @@ struct Screen: ReducerProtocol {
   }
   
   var body: some ReducerProtocol<State, Action> {
-    EmptyReducer()
-      .ifCaseLet(/State.home, action: /Action.home) {
-        Home()
-      }
-      .ifCaseLet(/State.numbersList, action: /Action.numbersList) {
-        NumbersList()
-      }
-      .ifCaseLet(/State.numberDetail, action: /Action.numberDetail) {
-        NumberDetail()
-      }
+    Scope(state: /State.home, action: /Action.home) {
+      Home()
+    }
+    Scope(state: /State.numbersList, action: /Action.numbersList) {
+      NumbersList()
+    }
+    Scope(state: /State.numberDetail, action: /Action.numberDetail) {
+      NumberDetail()
+    }
   }
 }
 ```


### PR DESCRIPTION
While `ifCaseLet`, `ifLet`, and `forEach` modifiers are required when enhancing a reducer that can change a given case, optional, or collection, for mutually exclusive "switches," it's perfectly fine to use `Scope` with a case path and avoid the `EmptyReducer` clunkiness.