### PR TITLE
Fix Most Deprecations for TCA 0.50.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "aa3e575929f2bcc5bad012bd2575eae716cbcdf7",
-          "version": "0.8.0"
+          "revision": "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
+          "version": "0.9.1"
         }
       },
       {
@@ -24,8 +24,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {
           "branch": null,
-          "revision": "15bba50ebf3a2065388c8d12210debe4f6ada202",
-          "version": "0.10.0"
+          "revision": "c3a42e8d1a76ff557cf565ed6d8b0aee0e6e75af",
+          "version": "0.11.0"
+        }
+      },
+      {
+        "package": "swift-clocks",
+        "repositoryURL": "https://github.com/pointfreeco/swift-clocks",
+        "state": {
+          "branch": null,
+          "revision": "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
+          "version": "0.2.0"
         }
       },
       {
@@ -33,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
-          "version": "1.0.3"
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
         }
       },
       {
@@ -42,8 +51,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture",
         "state": {
           "branch": null,
-          "revision": "5bd450a8ac6a802f82d485bac219cbfacffa69fb",
-          "version": "0.43.0"
+          "revision": "a99024bbd171d85a92bccbcea23e7c66f05dc12b",
+          "version": "0.50.2"
         }
       },
       {
@@ -51,8 +60,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
           "branch": null,
-          "revision": "819d9d370cd721c9d87671e29d947279292e4541",
-          "version": "0.6.0"
+          "revision": "dd86159e25c749873f144577e5d18309bf57534f",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "swift-dependencies",
+        "repositoryURL": "https://github.com/pointfreeco/swift-dependencies",
+        "state": {
+          "branch": null,
+          "revision": "8282b0c59662eb38946afe30eb403663fc2ecf76",
+          "version": "0.1.4"
         }
       },
       {
@@ -60,8 +78,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
         "state": {
           "branch": null,
-          "revision": "bfb0d43e75a15b6dfac770bf33479e8393884a36",
-          "version": "0.4.1"
+          "revision": "fd34c544ad27f3ba6b19142b348005bfa85b6005",
+          "version": "0.6.0"
+        }
+      },
+      {
+        "package": "swiftui-navigation",
+        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation",
+        "state": {
+          "branch": null,
+          "revision": "270a754308f5440be52fc295242eb7031638bd15",
+          "version": "0.6.1"
         }
       },
       {
@@ -69,8 +96,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "30314f1ece684dd60679d598a9b89107557b67d9",
-          "version": "0.4.1"
+          "revision": "ace21305e0dd3a9e749aef79fef14be79a3b4669",
+          "version": "0.8.2"
         }
       }
     ]

--- a/Sources/TCACoordinators/DeprecatedReducerExtensions/Reducer+tagging.swift
+++ b/Sources/TCACoordinators/DeprecatedReducerExtensions/Reducer+tagging.swift
@@ -41,7 +41,7 @@ extension AnyReducer {
       let effect = self.run(&state, action, environment)
       let postRoutes = routes(state)
 
-      var effects: [Effect<Action, Never>] = [effect]
+      var effects: [EffectTask<Action>] = [effect]
 
       let preIds = zip(preRoutes, preRoutes.indices).map(getIdentifier)
       let postIds = zip(postRoutes, postRoutes.indices).map(getIdentifier)
@@ -49,10 +49,10 @@ extension AnyReducer {
       let dismissedIds = Set(preIds).subtracting(postIds)
       for dismissedId in dismissedIds {
         let identity = CancellationIdentity(coordinatorId: coordinatorId, routeId: dismissedId)
-        effects.append(Effect<Action, Never>.cancel(id: AnyHashable(identity)))
+        effects.append(EffectTask<Action>.cancel(id: AnyHashable(identity)))
       }
 
-      return Effect.merge(effects)
+      return EffectTask.merge(effects)
     }
   }
 }

--- a/Sources/TCACoordinators/Effect+routeWithDelaysIfUnsupported.swift
+++ b/Sources/TCACoordinators/Effect+routeWithDelaysIfUnsupported.swift
@@ -5,7 +5,7 @@ import Foundation
 import SwiftUI
 import CombineSchedulers
 
-public extension Effect where Output: IndexedRouterAction, Failure == Never {
+public extension EffectPublisher where Action: IndexedRouterAction, Failure == Never {
   /// Allows arbitrary changes to be made to the routes collection, even if SwiftUI does not support such changes within a single
   /// state update. For example, SwiftUI only supports pushing, presenting or dismissing one screen at a time. Any changes can be
   /// made to the routes passed to the transform closure, and where those changes are not supported within a single update by
@@ -38,7 +38,7 @@ public extension Effect where Output: IndexedRouterAction, Failure == Never {
   }
 }
 
-public extension Effect where Output: IdentifiedRouterAction, Failure == Never {
+public extension EffectPublisher where Action: IdentifiedRouterAction, Failure == Never {
   /// Allows arbitrary changes to be made to the routes collection, even if SwiftUI does not support such changes within a single
   /// state update. For example, SwiftUI only supports pushing, presenting or dismissing one screen at a time. Any changes can be
   /// made to the routes passed to the transform closure, and where those changes are not supported within a single update by
@@ -70,21 +70,6 @@ public extension Effect where Output: IdentifiedRouterAction, Failure == Never {
     return routeWithDelaysIfUnsupported(routes, scheduler: DispatchQueue.main.eraseToAnyScheduler(), transform)
   }
 }
-
-///// Transforms a series of steps into an AnyPublisher of those steps, each one delayed in time.
-//func scheduledSteps<Screen>(steps: [[Route<Screen>]]) -> AnyPublisher<[Route<Screen>], Never> {
-//  guard let head = steps.first else {
-//    return Empty().eraseToAnyPublisher()
-//  }
-//
-//  let timer = Just(Date())
-//    .append(Timer.publish(every: 0.65, on: .main, in: .default).autoconnect())
-//  let tail = Publishers.Zip(steps.dropFirst().publisher, timer)
-//    .map { $0.0 }
-//  return Just(head)
-//    .append(tail)
-//    .eraseToAnyPublisher()
-//}
 
 /// Transforms a series of steps into an AnyPublisher of those steps, each one delayed in time.
 func scheduledSteps<Screen>(steps: [[Route<Screen>]], scheduler: AnySchedulerOf<DispatchQueue>) -> AnyPublisher<[Route<Screen>], Never> {

--- a/Sources/TCACoordinators/Reducers/CancelEffectsOnDismiss.swift
+++ b/Sources/TCACoordinators/Reducers/CancelEffectsOnDismiss.swift
@@ -73,7 +73,7 @@ struct CancelTaggedRouteEffectsOnDismiss<CoordinatorReducer: ReducerProtocol, Co
     let effect = coordinatorReducer.reduce(into: &state, action: action)
     let postRoutes = routes(state)
 
-    var effects: [Effect<Action, Never>] = [effect]
+    var effects: [EffectTask<Action>] = [effect]
 
     let preIds = zip(preRoutes, preRoutes.indices).map(getIdentifier)
     let postIds = zip(postRoutes, postRoutes.indices).map(getIdentifier)
@@ -81,9 +81,9 @@ struct CancelTaggedRouteEffectsOnDismiss<CoordinatorReducer: ReducerProtocol, Co
     let dismissedIds = Set(preIds).subtracting(postIds)
     for dismissedId in dismissedIds {
       let identity = CancellationIdentity(coordinatorId: coordinatorId, routeId: dismissedId)
-      effects.append(Effect<Action, Never>.cancel(id: AnyHashable(identity)))
+      effects.append(EffectTask<Action>.cancel(id: AnyHashable(identity)))
     }
 
-    return Effect.merge(effects)
+    return EffectTask.merge(effects)
   }
 }


### PR DESCRIPTION
This PR updates a few deprecations from the latest TCA, specifically the `EffectTask` and `EffectPublisher` types. There are two remaining deprecations from `ForEachIndexedRoute` where it needs to be refactored onto non-deprecated internal API. 