### PR TITLE
Fix ReducerBuilderOf Deprecation

### DIFF
--- a/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
@@ -34,7 +34,7 @@ public extension ReducerProtocol {
     toLocalState: WritableKeyPath<Self.State, IdentifiedArrayOf<Route<ScreenReducer.State>>>,
     toLocalAction: CasePath<Self.Action, (ScreenReducer.State.ID, ScreenReducer.Action)>,
     updateRoutes: CasePath<Self.Action, IdentifiedArrayOf<Route<ScreenReducer.State>>>,
-    @ReducerBuilderOf<ScreenReducer> screenReducer: () -> ScreenReducer
+    @ReducerBuilder<State, Action> screenReducer: () -> ScreenReducer
   ) -> some ReducerProtocol<State, Action> where ScreenReducer.State: Identifiable {
     return ForEachIdentifiedRoute(
       coordinatorReducer: self,
@@ -59,7 +59,7 @@ public extension ReducerProtocol where State: IdentifiedRouterState, Action: Ide
   /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
   func forEachRoute<ScreenReducer: ReducerProtocol, CoordinatorID: Hashable>(
     cancellationId: CoordinatorID?,
-    @ReducerBuilderOf<ScreenReducer> screenReducer: () -> ScreenReducer
+    @ReducerBuilder<State, Action> screenReducer: () -> ScreenReducer
   ) -> some ReducerProtocol<State, Action> where ScreenReducer.State: Identifiable, State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction {
     return ForEachIdentifiedRoute(
       coordinatorReducer: self,
@@ -82,7 +82,7 @@ public extension ReducerProtocol where State: IdentifiedRouterState, Action: Ide
   /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
   func forEachRoute<ScreenReducer: ReducerProtocol>(
     cancellationIdType: Any.Type = Self.self,
-    @ReducerBuilderOf<ScreenReducer> screenReducer: () -> ScreenReducer
+    @ReducerBuilder<State, Action> screenReducer: () -> ScreenReducer
   ) -> some ReducerProtocol<State, Action> where ScreenReducer.State: Identifiable, State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction {
     return ForEachIdentifiedRoute(
       coordinatorReducer: self,

--- a/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
@@ -37,7 +37,7 @@ public extension ReducerProtocol {
     toLocalState: WritableKeyPath<Self.State, [Route<ScreenReducer.State>]>,
     toLocalAction: CasePath<Self.Action, (Int, ScreenReducer.Action)>,
     updateRoutes: CasePath<Self.Action, [Route<ScreenReducer.State>]>,
-    @ReducerBuilderOf<ScreenReducer> screenReducer: () -> ScreenReducer
+    @ReducerBuilder<State, Action> screenReducer: () -> ScreenReducer
   ) -> some ReducerProtocol<State, Action> {
     return ForEachIndexedRoute(
       coordinatorReducer: self,
@@ -62,7 +62,7 @@ public extension ReducerProtocol where State: IndexedRouterState, Action: Indexe
   /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
   func forEachRoute<ScreenReducer: ReducerProtocol, CoordinatorID: Hashable>(
     coordinatorIdForCancellation: CoordinatorID?,
-    @ReducerBuilderOf<ScreenReducer> screenReducer: () -> ScreenReducer
+    @ReducerBuilder<State, Action> screenReducer: () -> ScreenReducer
   ) -> some ReducerProtocol<State, Action> where State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction {
     return ForEachIndexedRoute(
       coordinatorReducer: self,
@@ -85,7 +85,7 @@ public extension ReducerProtocol where State: IndexedRouterState, Action: Indexe
   /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
   func forEachRoute<ScreenReducer: ReducerProtocol>(
     cancellationIdType: Any.Type = Self.self,
-    @ReducerBuilderOf<ScreenReducer> screenReducer: () -> ScreenReducer
+    @ReducerBuilder<State, Action> screenReducer: () -> ScreenReducer
   ) -> some ReducerProtocol<State, Action> where State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction {
     return ForEachIndexedRoute(
       coordinatorReducer: self,


### PR DESCRIPTION
`ReducerBuilderOf` has been deprecated, so it's been replaced with `ReducerBuilder` with explicit generics. I think all of the `State, Action` types line up, as the compiler is okay, but you may want to take a second look.

I'm also tracking a regression in generic inference in Xcode 14.3 beta, where `forEachRoute` requires an explicit return type. It may be caused by `ReducerBuilderOf`, so I'll take another look when these changes are released.