### PR TITLE
Add ScreenState and ScreenAction Generics to Help Swift 5.8 Builder Type Inference

### DIFF
--- a/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
@@ -29,13 +29,14 @@ struct ForEachIdentifiedRoute<CoordinatorReducer: ReducerProtocol, ScreenReducer
 }
 
 public extension ReducerProtocol {
-  func forEachRoute<ScreenReducer: ReducerProtocol, CoordinatorID: Hashable>(
+  func forEachRoute<ScreenReducer: ReducerProtocol, ScreenState, ScreenAction, CoordinatorID: Hashable>(
     cancellationId: CoordinatorID?,
     toLocalState: WritableKeyPath<Self.State, IdentifiedArrayOf<Route<ScreenReducer.State>>>,
     toLocalAction: CasePath<Self.Action, (ScreenReducer.State.ID, ScreenReducer.Action)>,
     updateRoutes: CasePath<Self.Action, IdentifiedArrayOf<Route<ScreenReducer.State>>>,
-    @ReducerBuilder<ScreenReducer.State, ScreenReducer.Action> screenReducer: () -> ScreenReducer
-  ) -> some ReducerProtocol<State, Action> where ScreenReducer.State: Identifiable {
+    @ReducerBuilder<ScreenState, ScreenAction> screenReducer: () -> ScreenReducer
+  ) -> some ReducerProtocol<State, Action>
+    where ScreenReducer.State: Identifiable, ScreenState == ScreenReducer.State, ScreenAction == ScreenReducer.Action {
     return ForEachIdentifiedRoute(
       coordinatorReducer: self,
       screenReducer: screenReducer(),
@@ -57,10 +58,12 @@ public extension ReducerProtocol where State: IdentifiedRouterState, Action: Ide
   ///   will be combined with the screen's identifier.
   ///   - screenReducer: The reducer that operates on all of the individual screens.
   /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
-  func forEachRoute<ScreenReducer: ReducerProtocol, CoordinatorID: Hashable>(
+  func forEachRoute<ScreenReducer: ReducerProtocol, ScreenState, ScreenAction, CoordinatorID: Hashable>(
     cancellationId: CoordinatorID?,
-    @ReducerBuilder<ScreenReducer.State, ScreenReducer.Action> screenReducer: () -> ScreenReducer
-  ) -> some ReducerProtocol<State, Action> where ScreenReducer.State: Identifiable, State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction {
+    @ReducerBuilder<ScreenState, ScreenAction> screenReducer: () -> ScreenReducer
+  ) -> some ReducerProtocol<State, Action>
+    where ScreenReducer.State: Identifiable, State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction,
+          ScreenState == ScreenReducer.State, ScreenAction == ScreenReducer.Action {
     return ForEachIdentifiedRoute(
       coordinatorReducer: self,
       screenReducer: screenReducer(),
@@ -80,10 +83,12 @@ public extension ReducerProtocol where State: IdentifiedRouterState, Action: Ide
   ///   will be combined with the screen's identifier. Defaults to the type of the parent reducer.
   ///   - screenReducer: The reducer that operates on all of the individual screens.
   /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
-  func forEachRoute<ScreenReducer: ReducerProtocol>(
+    func forEachRoute<ScreenReducer: ReducerProtocol, ScreenState, ScreenAction>(
     cancellationIdType: Any.Type = Self.self,
-    @ReducerBuilder<ScreenReducer.State, ScreenReducer.Action> screenReducer: () -> ScreenReducer
-  ) -> some ReducerProtocol<State, Action> where ScreenReducer.State: Identifiable, State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction {
+    @ReducerBuilder<ScreenState, ScreenAction> screenReducer: () -> ScreenReducer
+  ) -> some ReducerProtocol<State, Action>
+    where ScreenReducer.State: Identifiable, State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction,
+          ScreenState == ScreenReducer.State, ScreenAction == ScreenReducer.Action {
     return ForEachIdentifiedRoute(
       coordinatorReducer: self,
       screenReducer: screenReducer(),

--- a/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
@@ -32,13 +32,13 @@ struct ForEachIndexedRoute<CoordinatorReducer: ReducerProtocol, ScreenReducer: R
 }
 
 public extension ReducerProtocol {
-  func forEachRoute<ScreenReducer: ReducerProtocol, CoordinatorID: Hashable>(
+  func forEachRoute<ScreenReducer: ReducerProtocol, ScreenState, ScreenAction, CoordinatorID: Hashable>(
     coordinatorIdForCancellation: CoordinatorID?,
     toLocalState: WritableKeyPath<Self.State, [Route<ScreenReducer.State>]>,
     toLocalAction: CasePath<Self.Action, (Int, ScreenReducer.Action)>,
     updateRoutes: CasePath<Self.Action, [Route<ScreenReducer.State>]>,
-    @ReducerBuilder<ScreenReducer.State, ScreenReducer.Action> screenReducer: () -> ScreenReducer
-  ) -> some ReducerProtocol<State, Action> {
+    @ReducerBuilder<ScreenState, ScreenAction> screenReducer: () -> ScreenReducer
+  ) -> some ReducerProtocol<State, Action> where ScreenState == ScreenReducer.State, ScreenAction == ScreenReducer.Action {
     return ForEachIndexedRoute(
       coordinatorReducer: self,
       screenReducer: screenReducer(),
@@ -60,10 +60,12 @@ public extension ReducerProtocol where State: IndexedRouterState, Action: Indexe
   ///   will be combined with the screen's identifier.
   ///   - screenReducer: The reducer that operates on all of the individual screens.
   /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
-  func forEachRoute<ScreenReducer: ReducerProtocol, CoordinatorID: Hashable>(
+  func forEachRoute<ScreenReducer: ReducerProtocol, ScreenState, ScreenAction, CoordinatorID: Hashable>(
     coordinatorIdForCancellation: CoordinatorID?,
-    @ReducerBuilder<ScreenReducer.State, ScreenReducer.Action> screenReducer: () -> ScreenReducer
-  ) -> some ReducerProtocol<State, Action> where State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction {
+    @ReducerBuilder<ScreenState, ScreenAction> screenReducer: () -> ScreenReducer
+  ) -> some ReducerProtocol<State, Action>
+    where State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction,
+          ScreenState == ScreenReducer.State, ScreenAction == ScreenReducer.Action {
     return ForEachIndexedRoute(
       coordinatorReducer: self,
       screenReducer: screenReducer(),
@@ -83,10 +85,12 @@ public extension ReducerProtocol where State: IndexedRouterState, Action: Indexe
   ///   will be combined with the screen's identifier. Defaults to the type of the parent reducer.
   ///   - screenReducer: The reducer that operates on all of the individual screens.
   /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
-  func forEachRoute<ScreenReducer: ReducerProtocol>(
+  func forEachRoute<ScreenReducer: ReducerProtocol, ScreenState, ScreenAction>(
     cancellationIdType: Any.Type = Self.self,
-    @ReducerBuilder<ScreenReducer.State, ScreenReducer.Action> screenReducer: () -> ScreenReducer
-  ) -> some ReducerProtocol<State, Action> where State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction {
+    @ReducerBuilder<ScreenState, ScreenAction> screenReducer: () -> ScreenReducer
+  ) -> some ReducerProtocol<State, Action>
+    where State.Screen == ScreenReducer.State, ScreenReducer.Action == Action.ScreenAction,
+          ScreenState == ScreenReducer.State, ScreenAction == ScreenReducer.Action {
     return ForEachIndexedRoute(
       coordinatorReducer: self,
       screenReducer: screenReducer(),


### PR DESCRIPTION
Swift 5.8 refactors the compiler's implementation of build inference for `@resultBuilder`s, which can lead to some previously accepted code producing a compiler error. TCACoordinators' `forEachRoute` implementation was one such case. For example:

```swift
Reduce { state, action in
    switch action {
    // Many actions elided.
    }
    return .none
}
.forEachRoute {
    NewExpenseFlow()
}
```

This failed due to an error, `Generic parameter 'ScreenReducer' could not be inferred`. Adding an explicit `() -> NewExpenseFlow in` return type to the builder closure fixed the issue. Ultimately, though, the issue was that the compiler can no longer infer the proper `State` and `Action` generics in the `ReducerBuilder` used by `forEachRoute`. This PR applies the fix suggested in that thread, the addition of explicit `ScreenState` and `ScreenAction` generics which are manually equated to the `ScreenReducer.State` and `ScreenReducer.Action`, providing the connection that was previously provided by the invalid inference.