### PR TITLE
Restore removeDuplicates and Fix observing stale state

### DIFF
--- a/Sources/TCACoordinators/TCARouter/TCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter.swift
@@ -58,7 +58,7 @@ public struct TCARouter<
     self.action = action
     self.identifier = identifier
     self.screenContent = screenContent
-    viewStore = ViewStore(store, observe: { $0 })
+    self.viewStore = ViewStore(store, observe: { $0 }, removeDuplicates: { routes($0).map(\.style) == routes($1).map(\.style) })
   }
 }
 

--- a/Sources/TCACoordinators/TCARouter/TCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter.swift
@@ -17,10 +17,10 @@ public struct TCARouter<
   let updateRoutes: ([Route<Screen>]) -> CoordinatorAction
   let action: (ID, ScreenAction) -> CoordinatorAction
   let identifier: (Screen, Int) -> ID
-
+  
   @ObservedObject private var viewStore: ViewStore<CoordinatorState, CoordinatorAction>
   @ViewBuilder var screenContent: (Store<Screen, ScreenAction>) -> ScreenContent
-
+  
   func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
     var screen = screen
     return store.scope(
@@ -34,16 +34,16 @@ public struct TCARouter<
       }
     )
   }
-
+  
   public var body: some View {
     Router(
-      viewStore.binding(get: routes, send: updateRoutes),
+      viewStore.binding(get: { _ in store.withState(routes) }, send: updateRoutes),
       buildView: { screen, index in
         screenContent(scopedStore(index: index, screen: screen))
       }
     )
   }
-
+  
   public init(
     store: Store<CoordinatorState, CoordinatorAction>,
     routes: @escaping (CoordinatorState) -> [Route<Screen>],


### PR DESCRIPTION
Restoring removeDuplicates to address performance improvements and resolve side-effect bugs, and making changes to ensure that the TCA router's viewStore always receives the up-to-date values.

close #57 