### PR TITLE
Observation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/johnpatrickmorgan/FlowStacks", from: "0.3.6"),
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.5.0"),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.8.0"),
   ],
   targets: [
     .target(

--- a/Sources/TCACoordinators/Collection+safeSubscript.swift
+++ b/Sources/TCACoordinators/Collection+safeSubscript.swift
@@ -1,0 +1,6 @@
+extension Collection {
+  /// Returns the element at the specified index if it is within bounds, otherwise nil.
+  subscript(safe index: Index) -> Element? {
+    indices.contains(index) ? self[index] : nil
+  }
+}

--- a/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
@@ -69,9 +69,9 @@ public extension Reducer {
   }
 
   func forEachRoute<ScreenState, ScreenAction>(
-    cancellationId: (some Hashable)?,
     _ routes: WritableKeyPath<Self.State, IdentifiedArrayOf<Route<ScreenState>>>,
-    action: CaseKeyPath<Self.Action, IdentifiedRouterAction<ScreenState, ScreenAction>>
+    action: CaseKeyPath<Self.Action, IdentifiedRouterAction<ScreenState, ScreenAction>>,
+    cancellationId: (some Hashable)?
   ) -> some ReducerOf<Self>
     where Action: CasePathable,
     ScreenState: CaseReducerState,

--- a/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
@@ -68,6 +68,16 @@ public extension Reducer {
     )
   }
 
+  /// Allows a screen case reducer to be incorporated into a coordinator reducer, such that each screen in
+  /// the coordinator's routes IdentifiedArray will have its actions and state propagated. When screens are
+  /// dismissed, the routes will be updated. In-flight effects will be cancelled when the screen from which they
+  /// originated is dismissed.
+  /// - Parameters:
+  ///   - routes: A writable keypath for the routes `IdentifiedArray`.
+  ///   - action: A casepath for the router action from this reducer's Action type.
+  ///   - cancellationId: An identifier to use for cancelling in-flight effects when a view is dismissed. It
+  ///   will be combined with the screen's identifier. If `nil`, there will be no automatic cancellation.
+  /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
   func forEachRoute<ScreenState, ScreenAction>(
     _ routes: WritableKeyPath<Self.State, IdentifiedArrayOf<Route<ScreenState>>>,
     action: CaseKeyPath<Self.Action, IdentifiedRouterAction<ScreenState, ScreenAction>>,
@@ -87,7 +97,7 @@ public extension Reducer {
     }
   }
 
-  /// Allows a screen reducer to be incorporated into a coordinator reducer, such that each screen in
+  /// Allows a screen case reducer to be incorporated into a coordinator reducer, such that each screen in
   /// the coordinator's routes IdentifiedArray will have its actions and state propagated. When screens are
   /// dismissed, the routes will be updated. If a cancellation identifier is passed, in-flight effects
   /// will be cancelled when the screen from which they originated is dismissed.
@@ -119,6 +129,16 @@ public extension Reducer {
     )
   }
 
+  /// Allows a screen case reducer to be incorporated into a coordinator reducer, such that each screen in
+  /// the coordinator's routes IdentifiedArray will have its actions and state propagated. When screens are
+  /// dismissed, the routes will be updated. In-flight effects will be cancelled when the screen from which they
+  /// originated is dismissed.
+  /// - Parameters:
+  ///   - routes: A writable keypath for the routes `IdentifiedArray`.
+  ///   - action: A casepath for the router action from this reducer's Action type.
+  ///   - cancellationIdType: A type to use for cancelling in-flight effects when a view is dismissed. It
+  ///   will be combined with the screen's identifier. Defaults to the type of the parent reducer.
+  /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
   func forEachRoute<ScreenState, ScreenAction>(
     _ routes: WritableKeyPath<State, IdentifiedArrayOf<Route<ScreenState>>>,
     action: CaseKeyPath<Action, IdentifiedRouterAction<ScreenState, ScreenAction>>,

--- a/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
@@ -70,8 +70,8 @@ public extension Reducer {
 
   func forEachRoute<ScreenState, ScreenAction>(
     cancellationId: (some Hashable)?,
-    toLocalState: WritableKeyPath<Self.State, IdentifiedArrayOf<Route<ScreenState>>>,
-    toLocalAction: CaseKeyPath<Self.Action, IdentifiedRouterAction<ScreenState, ScreenAction>>
+    _ routes: WritableKeyPath<Self.State, IdentifiedArrayOf<Route<ScreenState>>>,
+    action: CaseKeyPath<Self.Action, IdentifiedRouterAction<ScreenState, ScreenAction>>
   ) -> some ReducerOf<Self>
     where Action: CasePathable,
     ScreenState: CaseReducerState,
@@ -79,9 +79,9 @@ public extension Reducer {
     ScreenAction: CasePathable
   {
     self.forEachRoute(
-      cancellationId: cancellationId,
-      toLocalState: toLocalState,
-      toLocalAction: toLocalAction
+      routes,
+      action: action,
+      cancellationId: cancellationId
     ) {
       ScreenState.StateReducer.body
     }
@@ -120,9 +120,9 @@ public extension Reducer {
   }
 
   func forEachRoute<ScreenState, ScreenAction>(
-    cancellationIdType: Any.Type = Self.self,
     _ routes: WritableKeyPath<State, IdentifiedArrayOf<Route<ScreenState>>>,
-    action: CaseKeyPath<Action, IdentifiedRouterAction<ScreenState, ScreenAction>>
+    action: CaseKeyPath<Action, IdentifiedRouterAction<ScreenState, ScreenAction>>,
+    cancellationIdType: Any.Type = Self.self
   ) -> some ReducerOf<Self>
     where Action: CasePathable,
     ScreenState: CaseReducerState,
@@ -130,7 +130,7 @@ public extension Reducer {
     ScreenState.StateReducer.Action == ScreenAction,
     ScreenAction: CasePathable
   {
-    self.forEachRoute(cancellationIdType: cancellationIdType, routes, action: action) {
+    self.forEachRoute(routes, action: action, cancellationIdType: cancellationIdType) {
       ScreenState.StateReducer.body
     }
   }

--- a/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
@@ -57,6 +57,25 @@ public extension Reducer {
     )
   }
 
+  func forEachRoute<ScreenState, ScreenAction>(
+    cancellationId: (some Hashable)?,
+    toLocalState: WritableKeyPath<Self.State, IdentifiedArrayOf<Route<ScreenState>>>,
+    toLocalAction: CaseKeyPath<Self.Action, IdentifiedRouterAction<ScreenState, ScreenAction>>
+  ) -> some ReducerOf<Self>
+    where Action: CasePathable,
+    ScreenState: CaseReducerState,
+    ScreenState.StateReducer.Action == ScreenAction,
+    ScreenAction: CasePathable
+  {
+    self.forEachRoute(
+      cancellationId: cancellationId,
+      toLocalState: toLocalState,
+      toLocalAction: toLocalAction
+    ) {
+      ScreenState.StateReducer.body
+    }
+  }
+
   /// Allows a screen reducer to be incorporated into a coordinator reducer, such that each screen in
   /// the coordinator's routes IdentifiedArray will have its actions and state propagated. When screens are
   /// dismissed, the routes will be updated. If a cancellation identifier is passed, in-flight effects
@@ -85,6 +104,22 @@ public extension Reducer {
       toLocalState: routes,
       toLocalAction: action
     )
+  }
+
+  func forEachRoute<ScreenState, ScreenAction>(
+    cancellationIdType: Any.Type = Self.self,
+    _ routes: WritableKeyPath<State, IdentifiedArrayOf<Route<ScreenState>>>,
+    action: CaseKeyPath<Action, IdentifiedRouterAction<ScreenState, ScreenAction>>
+  ) -> some ReducerOf<Self>
+    where Action: CasePathable,
+    ScreenState: CaseReducerState,
+    ScreenState: Identifiable,
+    ScreenState.StateReducer.Action == ScreenAction,
+    ScreenAction: CasePathable
+  {
+    self.forEachRoute(cancellationIdType: cancellationIdType, routes, action: action) {
+      ScreenState.StateReducer.body
+    }
   }
 }
 

--- a/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
@@ -66,10 +66,20 @@ public extension Reducer {
     )
   }
 
+  /// Allows a screen case reducer to be incorporated into a coordinator reducer, such that each screen in
+  /// the coordinator's routes array will have its actions and state propagated. When screens are
+  /// dismissed, the routes will be updated. If a cancellation identifier is passed, in-flight effects
+  /// will be cancelled when the screen from which they originated is dismissed.
+  /// - Parameters:
+  ///   - routes: A writable keypath for the routes array.
+  ///   - action: A casepath for the router action from this reducer's Action type.
+  ///   - cancellationId: An identifier to use for cancelling in-flight effects when a view is dismissed. It
+  ///   will be combined with the screen's identifier. If `nil`, there will be no automatic cancellation.
+  /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
   func forEachRoute<ScreenState, ScreenAction>(
     _ routes: WritableKeyPath<Self.State, [Route<ScreenState>]>,
     action: CaseKeyPath<Self.Action, IndexedRouterAction<ScreenState, ScreenAction>>,
-    coordinatorId: (some Hashable)?
+    cancellationId: (some Hashable)?
   ) -> some ReducerOf<Self>
     where Action: CasePathable,
     ScreenState: CaseReducerState,
@@ -79,7 +89,7 @@ public extension Reducer {
     self.forEachRoute(
       routes,
       action: action,
-      cancellationId: coordinatorId
+      cancellationId: cancellationId
     ) {
       ScreenState.StateReducer.body
     }
@@ -116,7 +126,16 @@ public extension Reducer {
     )
   }
 
-  /// A special overload of ``Reducer.forEachRoute(_:action:cancellationIdType:screenReducer:)`` for enum reducers
+  /// Allows a screen case reducer to be incorporated into a coordinator reducer, such that each screen in
+  /// the coordinator's routes Array will have its actions and state propagated. When screens are
+  /// dismissed, the routes will be updated. In-flight effects will be cancelled when the screen from which
+  /// they originated is dismissed.
+  /// - Parameters:
+  ///   - routes: A writable keypath for the routes array.
+  ///   - action: A casepath for the router action from this reducer's Action type.
+  ///   - cancellationIdType: A type to use for cancelling in-flight effects when a view is dismissed. It
+  ///   will be combined with the screen's identifier. Defaults to the type of the parent reducer.
+  /// - Returns: A new reducer combining the coordinator-level and screen-level reducers.
   func forEachRoute<ScreenState, ScreenAction>(
     _ routes: WritableKeyPath<State, [Route<ScreenState>]>,
     action: CaseKeyPath<Action, IndexedRouterAction<ScreenState, ScreenAction>>,

--- a/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
@@ -55,6 +55,25 @@ public extension Reducer {
     )
   }
 
+  func forEachRoute<ScreenState, ScreenAction>(
+    coordinatorIdForCancellation: (some Hashable)?,
+    toLocalState: WritableKeyPath<Self.State, [Route<ScreenState>]>,
+    toLocalAction: CaseKeyPath<Self.Action, IndexedRouterAction<ScreenState, ScreenAction>>
+  ) -> some ReducerOf<Self>
+    where Action: CasePathable,
+    ScreenState: CaseReducerState,
+    ScreenState.StateReducer.Action == ScreenAction,
+    ScreenAction: CasePathable
+  {
+    self.forEachRoute(
+      coordinatorIdForCancellation: coordinatorIdForCancellation,
+      toLocalState: toLocalState,
+      toLocalAction: toLocalAction
+    ) {
+      ScreenState.StateReducer.body
+    }
+  }
+
   /// Allows a screen reducer to be incorporated into a coordinator reducer, such that each screen in
   /// the coordinator's routes Array will have its actions and state propagated. When screens are
   /// dismissed, the routes will be updated. If a cancellation identifier is passed, in-flight effects
@@ -82,5 +101,21 @@ public extension Reducer {
       toLocalState: routes,
       toLocalAction: action
     )
+  }
+
+  /// A special overload of ``Reducer.forEachRoute(_:action:cancellationIdType:screenReducer:)`` for enum reducers
+  func forEachRoute<ScreenState, ScreenAction>(
+    _ routes: WritableKeyPath<State, [Route<ScreenState>]>,
+    action: CaseKeyPath<Action, IndexedRouterAction<ScreenState, ScreenAction>>,
+    cancellationIdType: Any.Type = Self.self
+  ) -> some ReducerOf<Self>
+    where Action: CasePathable,
+    ScreenState: CaseReducerState,
+    ScreenState.StateReducer.Action == ScreenAction,
+    ScreenAction: CasePathable
+  {
+    self.forEachRoute(routes, action: action, cancellationIdType: cancellationIdType) {
+      ScreenState.StateReducer.body
+    }
   }
 }

--- a/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIndexedRoute.swift
@@ -67,9 +67,9 @@ public extension Reducer {
   }
 
   func forEachRoute<ScreenState, ScreenAction>(
-    coordinatorIdForCancellation: (some Hashable)?,
-    toLocalState: WritableKeyPath<Self.State, [Route<ScreenState>]>,
-    toLocalAction: CaseKeyPath<Self.Action, IndexedRouterAction<ScreenState, ScreenAction>>
+    _ routes: WritableKeyPath<Self.State, [Route<ScreenState>]>,
+    action: CaseKeyPath<Self.Action, IndexedRouterAction<ScreenState, ScreenAction>>,
+    coordinatorId: (some Hashable)?
   ) -> some ReducerOf<Self>
     where Action: CasePathable,
     ScreenState: CaseReducerState,
@@ -77,9 +77,9 @@ public extension Reducer {
     ScreenAction: CasePathable
   {
     self.forEachRoute(
-      coordinatorIdForCancellation: coordinatorIdForCancellation,
-      toLocalState: toLocalState,
-      toLocalAction: toLocalAction
+      routes,
+      action: action,
+      cancellationId: coordinatorId
     ) {
       ScreenState.StateReducer.body
     }

--- a/Sources/TCACoordinators/TCARouter/ObservedTCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/ObservedTCARouter.swift
@@ -8,12 +8,12 @@ public struct ObservedTCARouter<
   ID: Hashable,
   ScreenContent: View
 >: View {
-  @Perception.Bindable private var store: Store<[Route<Screen>], RouterAction<Screen, ID, ScreenAction>>
+  @Perception.Bindable private var store: Store<[Route<Screen>], RouterAction<ID, Screen, ScreenAction>>
   let identifier: (Screen, Int) -> ID
   let screenContent: (Store<Screen, ScreenAction>) -> ScreenContent
 
   public init(
-    store: Store<[Route<Screen>], RouterAction<Screen, ID, ScreenAction>>,
+    store: Store<[Route<Screen>], RouterAction<ID, Screen, ScreenAction>>,
     identifier: @escaping (Screen, Int) -> ID,
     @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
   ) {
@@ -53,8 +53,8 @@ public struct ObservedTCARouter<
 }
 
 private extension Store {
-  subscript<Screen, ID: Hashable, ScreenAction>() -> [Route<Screen>]
-    where State == [Route<Screen>], Action == RouterAction<Screen, ID, ScreenAction>
+  subscript<ID: Hashable, Screen, ScreenAction>() -> [Route<Screen>]
+    where State == [Route<Screen>], Action == RouterAction<ID, Screen, ScreenAction>
   {
     get { self.currentState }
     set {

--- a/Sources/TCACoordinators/TCARouter/ObservedTCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/ObservedTCARouter.swift
@@ -26,13 +26,13 @@ public struct ObservedTCARouter<
 		var screen = screen
 		let id = identifier(screen, index)
 		return store.scope(
-			id: store.id(state: \.[index], action: \.routeAction[id: id]),
+			id: store.id(state: \.[index], action: \.[id: id]),
 			state: ToState {
 				screen = $0[safe: index]?.screen ?? screen
 				return screen
 			},
 			action: {
-				.routeAction(.element(id: id, action: $0))
+				.routeAction(id: id, action: $0)
 			},
 			isInvalid: { !$0.indices.contains(index) }
 		)

--- a/Sources/TCACoordinators/TCARouter/ObservedTCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/ObservedTCARouter.swift
@@ -1,0 +1,63 @@
+@_spi(Internals) import ComposableArchitecture
+import FlowStacks
+import SwiftUI
+
+public struct ObservedTCARouter<
+	Screen: Equatable & ObservableState,
+	ScreenAction,
+	ID: Hashable,
+	ScreenContent: View
+>: View {
+	@Perception.Bindable private var store: Store<[Route<Screen>], RouterAction<Screen, ID, ScreenAction>>
+	let identifier: (Screen, Int) -> ID
+	let screenContent: (Store<Screen, ScreenAction>) -> ScreenContent
+
+	public init(
+		store: Store<[Route<Screen>], RouterAction<Screen, ID, ScreenAction>>,
+		identifier: @escaping (Screen, Int) -> ID,
+		@ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
+	) {
+		self.store = store
+		self.identifier = identifier
+		self.screenContent = screenContent
+	}
+
+	func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
+		var screen = screen
+		let id = identifier(screen, index)
+		return store.scope(
+			id: store.id(state: \.[index], action: \.routeAction[id: id]),
+			state: ToState {
+				screen = $0[safe: index]?.screen ?? screen
+				return screen
+			},
+			action: {
+				.routeAction(.element(id: id, action: $0))
+			},
+			isInvalid: { !$0.indices.contains(index) }
+		)
+	}
+
+	public var body: some View {
+		WithPerceptionTracking {
+			Router(
+				$store[],
+				buildView: { screen, index in
+					WithPerceptionTracking {
+						screenContent(scopedStore(index: index, screen: screen))
+					}
+				}
+			)
+		}
+	}
+}
+
+extension Store {
+	fileprivate subscript<Screen, ID: Hashable, ScreenAction>() -> [Route<Screen>]
+	where State == [Route<Screen>], Action == RouterAction<Screen, ID, ScreenAction> {
+		get { self.currentState }
+		set {
+			self.send(.updateRoutes(newValue))
+		}
+	}
+}

--- a/Sources/TCACoordinators/TCARouter/ObservedTCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/ObservedTCARouter.swift
@@ -3,61 +3,62 @@ import FlowStacks
 import SwiftUI
 
 public struct ObservedTCARouter<
-	Screen: Equatable & ObservableState,
-	ScreenAction,
-	ID: Hashable,
-	ScreenContent: View
+  Screen: Equatable & ObservableState,
+  ScreenAction,
+  ID: Hashable,
+  ScreenContent: View
 >: View {
-	@Perception.Bindable private var store: Store<[Route<Screen>], RouterAction<Screen, ID, ScreenAction>>
-	let identifier: (Screen, Int) -> ID
-	let screenContent: (Store<Screen, ScreenAction>) -> ScreenContent
+  @Perception.Bindable private var store: Store<[Route<Screen>], RouterAction<Screen, ID, ScreenAction>>
+  let identifier: (Screen, Int) -> ID
+  let screenContent: (Store<Screen, ScreenAction>) -> ScreenContent
 
-	public init(
-		store: Store<[Route<Screen>], RouterAction<Screen, ID, ScreenAction>>,
-		identifier: @escaping (Screen, Int) -> ID,
-		@ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
-	) {
-		self.store = store
-		self.identifier = identifier
-		self.screenContent = screenContent
-	}
+  public init(
+    store: Store<[Route<Screen>], RouterAction<Screen, ID, ScreenAction>>,
+    identifier: @escaping (Screen, Int) -> ID,
+    @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
+  ) {
+    self.store = store
+    self.identifier = identifier
+    self.screenContent = screenContent
+  }
 
-	func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
-		var screen = screen
-		let id = identifier(screen, index)
-		return store.scope(
-			id: store.id(state: \.[index], action: \.[id: id]),
-			state: ToState {
-				screen = $0[safe: index]?.screen ?? screen
-				return screen
-			},
-			action: {
-				.routeAction(id: id, action: $0)
-			},
-			isInvalid: { !$0.indices.contains(index) }
-		)
-	}
+  func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
+    var screen = screen
+    let id = identifier(screen, index)
+    return store.scope(
+      id: store.id(state: \.[index], action: \.[id: id]),
+      state: ToState {
+        screen = $0[safe: index]?.screen ?? screen
+        return screen
+      },
+      action: {
+        .routeAction(id: id, action: $0)
+      },
+      isInvalid: { !$0.indices.contains(index) }
+    )
+  }
 
-	public var body: some View {
-		WithPerceptionTracking {
-			Router(
-				$store[],
-				buildView: { screen, index in
-					WithPerceptionTracking {
-						screenContent(scopedStore(index: index, screen: screen))
-					}
-				}
-			)
-		}
-	}
+  public var body: some View {
+    WithPerceptionTracking {
+      Router(
+        $store[],
+        buildView: { screen, index in
+          WithPerceptionTracking {
+            screenContent(scopedStore(index: index, screen: screen))
+          }
+        }
+      )
+    }
+  }
 }
 
-extension Store {
-	fileprivate subscript<Screen, ID: Hashable, ScreenAction>() -> [Route<Screen>]
-	where State == [Route<Screen>], Action == RouterAction<Screen, ID, ScreenAction> {
-		get { self.currentState }
-		set {
-			self.send(.updateRoutes(newValue))
-		}
-	}
+private extension Store {
+  subscript<Screen, ID: Hashable, ScreenAction>() -> [Route<Screen>]
+    where State == [Route<Screen>], Action == RouterAction<Screen, ID, ScreenAction>
+  {
+    get { self.currentState }
+    set {
+      self.send(.updateRoutes(newValue))
+    }
+  }
 }

--- a/Sources/TCACoordinators/TCARouter/TCARouter+IdentifiedScreen.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter+IdentifiedScreen.swift
@@ -17,20 +17,6 @@ public extension TCARouter where Screen: Identifiable {
   }
 }
 
-public extension ObservedTCARouter where Screen: Identifiable {
-  /// Convenience initializer for managing screens in an `IdentifiedArray`.
-  init(
-    _ store: Store<IdentifiedArrayOf<Route<Screen>>, IdentifiedRouterAction<Screen, ScreenAction>>,
-    @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
-  ) where Screen.ID == ID {
-    self.init(
-      store: store.scope(state: \.elements, action: \.self),
-      identifier: { state, _ in state.id },
-      screenContent: screenContent
-    )
-  }
-}
-
 extension Route: Identifiable where Screen: Identifiable {
   public var id: Screen.ID { screen.id }
 }

--- a/Sources/TCACoordinators/TCARouter/TCARouter+IdentifiedScreen.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter+IdentifiedScreen.swift
@@ -7,7 +7,7 @@ public extension TCARouter where Screen: Identifiable {
   /// Convenience initializer for managing screens in an `IdentifiedArray`.
   init(
     _ store: Store<IdentifiedArrayOf<Route<Screen>>, IdentifiedRouterAction<Screen, ScreenAction>>,
-    screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
+    @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
   ) where Screen.ID == ID {
     self.init(
       store: store.scope(state: \.elements, action: \.self),
@@ -16,6 +16,21 @@ public extension TCARouter where Screen: Identifiable {
     )
   }
 }
+
+public extension ObservedTCARouter where Screen: Identifiable {
+  /// Convenience initializer for managing screens in an `IdentifiedArray`.
+  init(
+    _ store: Store<IdentifiedArrayOf<Route<Screen>>, IdentifiedRouterAction<Screen, ScreenAction>>,
+    @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
+  ) where Screen.ID == ID {
+    self.init(
+      store: store.scope(state: \.elements, action: \.self),
+      identifier: { state, _ in state.id },
+      screenContent: screenContent
+    )
+  }
+}
+
 
 extension Route: Identifiable where Screen: Identifiable {
   public var id: Screen.ID { screen.id }

--- a/Sources/TCACoordinators/TCARouter/TCARouter+IdentifiedScreen.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter+IdentifiedScreen.swift
@@ -31,7 +31,6 @@ public extension ObservedTCARouter where Screen: Identifiable {
   }
 }
 
-
 extension Route: Identifiable where Screen: Identifiable {
   public var id: Screen.ID { screen.id }
 }

--- a/Sources/TCACoordinators/TCARouter/TCARouter+IndexedScreen.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter+IndexedScreen.swift
@@ -7,7 +7,21 @@ public extension TCARouter where ID == Int {
   /// Convenience initializer for managing screens in an `Array`, identified by index.
   init(
     _ store: Store<[Route<Screen>], IndexedRouterAction<Screen, ScreenAction>>,
-    screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
+    @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
+  ) {
+    self.init(
+      store: store,
+      identifier: { $1 },
+      screenContent: screenContent
+    )
+  }
+}
+
+public extension ObservedTCARouter where ID == Int {
+  /// Convenience initializer for managing screens in an `Array`, identified by index.
+  init(
+    _ store: Store<[Route<Screen>], IndexedRouterAction<Screen, ScreenAction>>,
+    @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
   ) {
     self.init(
       store: store,

--- a/Sources/TCACoordinators/TCARouter/TCARouter+IndexedScreen.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter+IndexedScreen.swift
@@ -16,17 +16,3 @@ public extension TCARouter where ID == Int {
     )
   }
 }
-
-public extension ObservedTCARouter where ID == Int {
-  /// Convenience initializer for managing screens in an `Array`, identified by index.
-  init(
-    _ store: Store<[Route<Screen>], IndexedRouterAction<Screen, ScreenAction>>,
-    @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
-  ) {
-    self.init(
-      store: store,
-      identifier: { $1 },
-      screenContent: screenContent
-    )
-  }
-}

--- a/Sources/TCACoordinators/TCARouter/UnobservedTCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/UnobservedTCARouter.swift
@@ -16,7 +16,7 @@ struct UnobservedTCARouter<
   let identifier: (Screen, Int) -> ID
   let screenContent: (Store<Screen, ScreenAction>) -> ScreenContent
 
-  public init(
+  init(
     store: Store<[Route<Screen>], RouterAction<ID, Screen, ScreenAction>>,
     identifier: @escaping (Screen, Int) -> ID,
     @ViewBuilder screenContent: @escaping (Store<Screen, ScreenAction>) -> ScreenContent
@@ -42,7 +42,7 @@ struct UnobservedTCARouter<
     )
   }
 
-  public var body: some View {
+  var body: some View {
     WithViewStore(store, observe: { $0 }) { viewStore in
       Router(
         viewStore

--- a/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
+++ b/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		529822D7283D76F60011112B /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529822D6283D76F60011112B /* WelcomeView.swift */; };
 		529822D9283D77060011112B /* LogInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529822D8283D77060011112B /* LogInView.swift */; };
 		912FC7232BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */; };
+		912FC7252BEBAFAA0036B444 /* FormScreen+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912FC7242BEBAFAA0036B444 /* FormScreen+Identifiable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,6 +87,7 @@
 		529822D6283D76F60011112B /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		529822D8283D77060011112B /* LogInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogInView.swift; sourceTree = "<group>"; };
 		912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LogInScreen+StateIdentifiable.swift"; sourceTree = "<group>"; };
+		912FC7242BEBAFAA0036B444 /* FormScreen+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormScreen+Identifiable.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -197,6 +199,7 @@
 			children = (
 				528FEDE62880BC60007765AD /* FormAppCoordinator.swift */,
 				528FEDE42880BC60007765AD /* FormScreen.swift */,
+				912FC7242BEBAFAA0036B444 /* FormScreen+Identifiable.swift */,
 				528FEDE72880BC60007765AD /* FinalScreen.swift */,
 				528FEDE82880BC61007765AD /* Step1.swift */,
 				528FEDE92880BC61007765AD /* Step2.swift */,
@@ -361,6 +364,7 @@
 				528FEDF42880BD95007765AD /* FinalScreen.swift in Sources */,
 				529822D7283D76F60011112B /* WelcomeView.swift in Sources */,
 				528FEDF52880BD95007765AD /* FormScreen.swift in Sources */,
+				912FC7252BEBAFAA0036B444 /* FormScreen+Identifiable.swift in Sources */,
 				912FC7232BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift in Sources */,
 				524087E5278E3D950048C6EE /* Screen.swift in Sources */,
 				528FEDF22880BD95007765AD /* Step3.swift in Sources */,

--- a/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
+++ b/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		529822D9283D77060011112B /* LogInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529822D8283D77060011112B /* LogInView.swift */; };
 		912FC7232BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */; };
 		912FC7252BEBAFAA0036B444 /* FormScreen+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912FC7242BEBAFAA0036B444 /* FormScreen+Identifiable.swift */; };
+		912FC7272BEBB9080036B444 /* GameViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912FC7262BEBB9080036B444 /* GameViewState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		529822D8283D77060011112B /* LogInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogInView.swift; sourceTree = "<group>"; };
 		912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LogInScreen+StateIdentifiable.swift"; sourceTree = "<group>"; };
 		912FC7242BEBAFAA0036B444 /* FormScreen+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormScreen+Identifiable.swift"; sourceTree = "<group>"; };
+		912FC7262BEBB9080036B444 /* GameViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameViewState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -212,6 +214,7 @@
 			isa = PBXGroup;
 			children = (
 				529822CE283D76AD0011112B /* GameView.swift */,
+				912FC7262BEBB9080036B444 /* GameViewState.swift */,
 				529822CF283D76AD0011112B /* AppCoordinator.swift */,
 				529822D0283D76AD0011112B /* LogInCoordinator.swift */,
 				912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */,
@@ -373,6 +376,7 @@
 				528FEDF62880BD95007765AD /* FormAppCoordinator.swift in Sources */,
 				529822D2283D76AD0011112B /* GameView.swift in Sources */,
 				528FEDF32880BD95007765AD /* Step1.swift in Sources */,
+				912FC7272BEBB9080036B444 /* GameViewState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
+++ b/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		5248864D26F2A26500970899 /* TCACoordinatorsExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248864C26F2A26500970899 /* TCACoordinatorsExampleUITestsLaunchTests.swift */; };
 		5248866026F2A53B00970899 /* TCACoordinators in Frameworks */ = {isa = PBXBuildFile; productRef = 5248865F26F2A53B00970899 /* TCACoordinators */; };
 		528AE0E92BECE20F00E143C5 /* FormScreen+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912FC7242BEBAFAA0036B444 /* FormScreen+Identifiable.swift */; };
+		528AE0EB2BED197000E143C5 /* OutcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528AE0EA2BED197000E143C5 /* OutcomeView.swift */; };
 		528FEDEB2880BD94007765AD /* Step3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528FEDEA2880BC61007765AD /* Step3.swift */; };
 		528FEDEC2880BD94007765AD /* Step1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528FEDE82880BC61007765AD /* Step1.swift */; };
 		528FEDED2880BD94007765AD /* FinalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528FEDE72880BC60007765AD /* FinalScreen.swift */; };
@@ -76,6 +77,7 @@
 		5248864A26F2A26500970899 /* TCACoordinatorsExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCACoordinatorsExampleUITests.swift; sourceTree = "<group>"; };
 		5248864C26F2A26500970899 /* TCACoordinatorsExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCACoordinatorsExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		5248865A26F2A2C200970899 /* TCACoordinators */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TCACoordinators; path = ..; sourceTree = "<group>"; };
+		528AE0EA2BED197000E143C5 /* OutcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutcomeView.swift; sourceTree = "<group>"; };
 		528FEDE42880BC60007765AD /* FormScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormScreen.swift; sourceTree = "<group>"; };
 		528FEDE62880BC60007765AD /* FormAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormAppCoordinator.swift; sourceTree = "<group>"; };
 		528FEDE72880BC60007765AD /* FinalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinalScreen.swift; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 				912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */,
 				529822D1283D76AD0011112B /* GameCoordinator.swift */,
 				529822D6283D76F60011112B /* WelcomeView.swift */,
+				528AE0EA2BED197000E143C5 /* OutcomeView.swift */,
 				529822D8283D77060011112B /* LogInView.swift */,
 			);
 			path = Game;
@@ -374,6 +377,7 @@
 				528FEDF22880BD95007765AD /* Step3.swift in Sources */,
 				529822D3283D76AD0011112B /* AppCoordinator.swift in Sources */,
 				524087E6278E3D950048C6EE /* IdentifiedCoordinator.swift in Sources */,
+				528AE0EB2BED197000E143C5 /* OutcomeView.swift in Sources */,
 				528FEDF62880BD95007765AD /* FormAppCoordinator.swift in Sources */,
 				529822D2283D76AD0011112B /* GameView.swift in Sources */,
 				528FEDF32880BD95007765AD /* Step1.swift in Sources */,

--- a/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
+++ b/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		529822D5283D76AD0011112B /* GameCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529822D1283D76AD0011112B /* GameCoordinator.swift */; };
 		529822D7283D76F60011112B /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529822D6283D76F60011112B /* WelcomeView.swift */; };
 		529822D9283D77060011112B /* LogInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529822D8283D77060011112B /* LogInView.swift */; };
+		912FC7232BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 		529822D1283D76AD0011112B /* GameCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameCoordinator.swift; sourceTree = "<group>"; };
 		529822D6283D76F60011112B /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		529822D8283D77060011112B /* LogInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogInView.swift; sourceTree = "<group>"; };
+		912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LogInScreen+StateIdentifiable.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -209,6 +211,7 @@
 				529822CE283D76AD0011112B /* GameView.swift */,
 				529822CF283D76AD0011112B /* AppCoordinator.swift */,
 				529822D0283D76AD0011112B /* LogInCoordinator.swift */,
+				912FC7222BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift */,
 				529822D1283D76AD0011112B /* GameCoordinator.swift */,
 				529822D6283D76F60011112B /* WelcomeView.swift */,
 				529822D8283D77060011112B /* LogInView.swift */,
@@ -358,6 +361,7 @@
 				528FEDF42880BD95007765AD /* FinalScreen.swift in Sources */,
 				529822D7283D76F60011112B /* WelcomeView.swift in Sources */,
 				528FEDF52880BD95007765AD /* FormScreen.swift in Sources */,
+				912FC7232BEBAB7A0036B444 /* LogInScreen+StateIdentifiable.swift in Sources */,
 				524087E5278E3D950048C6EE /* Screen.swift in Sources */,
 				528FEDF22880BD95007765AD /* Step3.swift in Sources */,
 				529822D3283D76AD0011112B /* AppCoordinator.swift in Sources */,

--- a/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
+++ b/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5248864B26F2A26500970899 /* TCACoordinatorsExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248864A26F2A26500970899 /* TCACoordinatorsExampleUITests.swift */; };
 		5248864D26F2A26500970899 /* TCACoordinatorsExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248864C26F2A26500970899 /* TCACoordinatorsExampleUITestsLaunchTests.swift */; };
 		5248866026F2A53B00970899 /* TCACoordinators in Frameworks */ = {isa = PBXBuildFile; productRef = 5248865F26F2A53B00970899 /* TCACoordinators */; };
+		528AE0E92BECE20F00E143C5 /* FormScreen+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912FC7242BEBAFAA0036B444 /* FormScreen+Identifiable.swift */; };
 		528FEDEB2880BD94007765AD /* Step3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528FEDEA2880BC61007765AD /* Step3.swift */; };
 		528FEDEC2880BD94007765AD /* Step1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528FEDE82880BC61007765AD /* Step1.swift */; };
 		528FEDED2880BD94007765AD /* FinalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528FEDE72880BC60007765AD /* FinalScreen.swift */; };
@@ -389,6 +390,7 @@
 				5248864126F2A26500970899 /* TCACoordinatorsExampleTests.swift in Sources */,
 				528FEDED2880BD94007765AD /* FinalScreen.swift in Sources */,
 				524087E7278E3D9F0048C6EE /* IdentifiedCoordinator.swift in Sources */,
+				528AE0E92BECE20F00E143C5 /* FormScreen+Identifiable.swift in Sources */,
 				528FEDF12880BD94007765AD /* Step2.swift in Sources */,
 				524087E9278E3D9F0048C6EE /* Screen.swift in Sources */,
 				528FEDEF2880BD94007765AD /* FormAppCoordinator.swift in Sources */,

--- a/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-dependencies",
         "state": {
           "branch": null,
-          "revision": "63301f4a181ed9aefb46dccef2dfb66466798341",
-          "version": "1.1.1"
+          "revision": "d3a5af3038a09add4d7682f66555d6212058a3c0",
+          "version": "1.2.2"
         }
       },
       {

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/FinalScreen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/FinalScreen.swift
@@ -92,7 +92,8 @@ struct APIModel: Codable, Equatable {
   let job: String
 }
 
-struct FinalScreen: Reducer {
+@Reducer
+struct FinalScreen {
   @ObservableState
   struct State: Equatable {
     let firstName: String

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormAppCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormAppCoordinator.swift
@@ -4,6 +4,7 @@ import TCACoordinators
 
 @Reducer
 struct FormAppCoordinator {
+  @ObservableState
   struct State: Equatable {
     static let initialState = Self(routeIDs: [.root(.step1, embedInNavigationView: true)])
 
@@ -104,9 +105,7 @@ struct FormAppCoordinator {
         return .none
       }
     }
-    .forEachRoute(\.routes, action: \.router) {
-      FormScreen(environment: .test)
-    }
+    .forEachRoute(\.routes, action: \.router)
   }
 }
 
@@ -114,21 +113,19 @@ struct FormAppCoordinatorView: View {
   let store: StoreOf<FormAppCoordinator>
 
   var body: some View {
-    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
-      SwitchStore(screen) { screen in
-        switch screen {
-        case .step1:
-          CaseLet(\FormScreen.State.step1, action: FormScreen.Action.step1, then: Step1View.init(store:))
+    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+      switch screen.case {
+      case let .step1(store):
+        Step1View(store: store)
 
-        case .step2:
-          CaseLet(\FormScreen.State.step2, action: FormScreen.Action.step2, then: Step2View.init(store:))
+      case let .step2(store):
+        Step2View(store: store)
 
-        case .step3:
-          CaseLet(\FormScreen.State.step3, action: FormScreen.Action.step3, then: Step3View.init(store:))
+      case let .step3(store):
+        Step3View(store: store)
 
-        case .finalScreen:
-          CaseLet(\FormScreen.State.finalScreen, action: FormScreen.Action.finalScreen, then: FinalScreenView.init(store:))
-        }
+      case let .finalScreen(store):
+        FinalScreenView(store: store)
       }
     }
   }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormAppCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormAppCoordinator.swift
@@ -113,7 +113,7 @@ struct FormAppCoordinatorView: View {
   let store: StoreOf<FormAppCoordinator>
 
   var body: some View {
-    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
       switch screen.case {
       case let .step1(store):
         Step1View(store: store)

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormScreen+Identifiable.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormScreen+Identifiable.swift
@@ -1,0 +1,23 @@
+extension FormScreen.State: Identifiable {
+  var id: ID {
+    switch self {
+    case .step1:
+      return .step1
+    case .step2:
+      return .step2
+    case .step3:
+      return .step3
+    case .finalScreen:
+      return .finalScreen
+    }
+  }
+
+  enum ID: Identifiable {
+    case step1
+    case step2
+    case step3
+    case finalScreen
+
+    var id: ID { self }
+  }
+}

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormScreen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormScreen.swift
@@ -1,11 +1,12 @@
 import ComposableArchitecture
 import Foundation
 
-struct FormScreenEnvironment {
-  let getOccupations: () async -> [String]
-  let submit: (APIModel) async -> Bool
+@DependencyClient
+struct FormScreenEnvironment: DependencyKey {
+  var getOccupations: () async -> [String] = { [] }
+  var submit: (APIModel) async -> Bool = { _ in false }
 
-  static let test = FormScreenEnvironment(
+  static let liveValue = FormScreenEnvironment(
     getOccupations: {
       [
         "iOS Developer",
@@ -20,60 +21,10 @@ struct FormScreenEnvironment {
   )
 }
 
-@Reducer
-struct FormScreen: Reducer {
-  let environment: FormScreenEnvironment
-
-  enum State: Equatable, Identifiable {
-    case step1(Step1.State)
-    case step2(Step2.State)
-    case step3(Step3.State)
-    case finalScreen(FinalScreen.State)
-
-    var id: ID {
-      switch self {
-      case .step1:
-        return .step1
-      case .step2:
-        return .step2
-      case .step3:
-        return .step3
-      case .finalScreen:
-        return .finalScreen
-      }
-    }
-
-    enum ID: Identifiable {
-      case step1
-      case step2
-      case step3
-      case finalScreen
-
-      var id: ID {
-        self
-      }
-    }
-  }
-
-  enum Action: Equatable {
-    case step1(Step1.Action)
-    case step2(Step2.Action)
-    case step3(Step3.Action)
-    case finalScreen(FinalScreen.Action)
-  }
-
-  var body: some ReducerOf<Self> {
-    Scope(state: /State.step1, action: /Action.step1) {
-      Step1()
-    }
-    Scope(state: /State.step2, action: /Action.step2) {
-      Step2()
-    }
-    Scope(state: /State.step3, action: /Action.step3) {
-      Step3(getOccupations: environment.getOccupations)
-    }
-    Scope(state: /State.finalScreen, action: /Action.finalScreen) {
-      FinalScreen(submit: environment.submit)
-    }
-  }
+@Reducer(state: .equatable)
+enum FormScreen {
+  case step1(Step1)
+  case step2(Step2)
+  case step3(Step3)
+  case finalScreen(FinalScreen)
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step1.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step1.swift
@@ -2,9 +2,10 @@ import ComposableArchitecture
 import SwiftUI
 
 struct Step1: Reducer {
+  @ObservableState
   public struct State: Equatable {
-    @BindingState var firstName: String = ""
-    @BindingState var lastName: String = ""
+    var firstName: String = ""
+    var lastName: String = ""
   }
 
   public enum Action: Equatable, BindableAction {
@@ -18,17 +19,17 @@ struct Step1: Reducer {
 }
 
 struct Step1View: View {
-  let store: StoreOf<Step1>
+  @Perception.Bindable var store: StoreOf<Step1>
 
   var body: some View {
-    WithViewStore(store, observe: { $0 }) { viewStore in
+    WithPerceptionTracking {
       Form {
-        TextField("First Name", text: viewStore.$firstName)
-        TextField("Last Name", text: viewStore.$lastName)
+        TextField("First Name", text: $store.firstName)
+        TextField("Last Name", text: $store.lastName)
 
         Section {
           Button("Next") {
-            viewStore.send(.nextButtonTapped)
+            store.send(.nextButtonTapped)
           }
         }
       }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step1.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step1.swift
@@ -1,7 +1,8 @@
 import ComposableArchitecture
 import SwiftUI
 
-struct Step1: Reducer {
+@Reducer
+struct Step1 {
   @ObservableState
   public struct State: Equatable {
     var firstName: String = ""

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step2.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step2.swift
@@ -28,7 +28,8 @@ struct Step2View: View {
   }
 }
 
-struct Step2: Reducer {
+@Reducer
+struct Step2 {
   @ObservableState
   public struct State: Equatable {
     var dateOfBirth: Date = .now

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step2.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step2.swift
@@ -2,15 +2,15 @@ import ComposableArchitecture
 import SwiftUI
 
 struct Step2View: View {
-  let store: StoreOf<Step2>
+  @Perception.Bindable var store: StoreOf<Step2>
 
   var body: some View {
-    WithViewStore(store, observe: { $0 }) { viewStore in
+    WithPerceptionTracking {
       Form {
         Section {
           DatePicker(
             "Date of Birth",
-            selection: viewStore.$dateOfBirth,
+            selection: $store.dateOfBirth,
             in: ...Date.now,
             displayedComponents: .date
           )
@@ -20,7 +20,7 @@ struct Step2View: View {
         }
 
         Button("Next") {
-          viewStore.send(.nextButtonTapped)
+          store.send(.nextButtonTapped)
         }
       }
       .navigationTitle("Step 2")
@@ -29,8 +29,9 @@ struct Step2View: View {
 }
 
 struct Step2: Reducer {
+  @ObservableState
   public struct State: Equatable {
-    @BindingState var dateOfBirth: Date = .now
+    var dateOfBirth: Date = .now
   }
 
   public enum Action: Equatable, BindableAction {

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step3.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step3.swift
@@ -47,7 +47,8 @@ struct Step3View: View {
   }
 }
 
-struct Step3: Reducer {
+@Reducer
+struct Step3 {
   @ObservableState
   struct State: Equatable {
     var selectedOccupation: String?

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step3.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step3.swift
@@ -5,20 +5,20 @@ struct Step3View: View {
   let store: StoreOf<Step3>
 
   var body: some View {
-    WithViewStore(store, observe: { $0 }) { viewStore in
+    WithPerceptionTracking {
       Form {
         Section {
-          if !viewStore.occupations.isEmpty {
-            List(viewStore.occupations, id: \.self) { occupation in
+          if !store.occupations.isEmpty {
+            List(store.occupations, id: \.self) { occupation in
               Button {
-                viewStore.send(.selectOccupation(occupation))
+                store.send(.selectOccupation(occupation))
               } label: {
                 HStack {
                   Text(occupation)
 
                   Spacer()
 
-                  if let selected = viewStore.selectedOccupation, selected == occupation {
+                  if let selected = store.selectedOccupation, selected == occupation {
                     Image(systemName: "checkmark")
                   }
                 }
@@ -34,11 +34,11 @@ struct Step3View: View {
         }
 
         Button("Next") {
-          viewStore.send(.nextButtonTapped)
+          store.send(.nextButtonTapped)
         }
       }
       .onAppear {
-        viewStore.send(.getOccupations)
+        store.send(.getOccupations)
       }
       .navigationTitle("Step 3")
     }
@@ -46,6 +46,7 @@ struct Step3View: View {
 }
 
 struct Step3: Reducer {
+  @ObservableState
   struct State: Equatable {
     var selectedOccupation: String?
     var occupations: [String] = []
@@ -58,14 +59,14 @@ struct Step3: Reducer {
     case nextButtonTapped
   }
 
-  let getOccupations: () async -> [String]
+  @Dependency(FormScreenEnvironment.self) var environment
 
   var body: some ReducerOf<Self> {
     Reduce { state, action in
       switch action {
       case .getOccupations:
         return .run { send in
-          await send(.receiveOccupations(getOccupations()))
+          await send(.receiveOccupations(environment.getOccupations()))
         }
 
       case let .receiveOccupations(occupations):

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step3.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step3.swift
@@ -14,12 +14,14 @@ struct Step3View: View {
                 store.send(.selectOccupation(occupation))
               } label: {
                 HStack {
-                  Text(occupation)
-
-                  Spacer()
-
-                  if let selected = store.selectedOccupation, selected == occupation {
-                    Image(systemName: "checkmark")
+                  WithPerceptionTracking {
+                    Text(occupation)
+                    
+                    Spacer()
+                    
+                    if let selected = store.selectedOccupation, selected == occupation {
+                      Image(systemName: "checkmark")
+                    }
                   }
                 }
               }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/AppCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/AppCoordinator.swift
@@ -8,9 +8,9 @@ struct AppCoordinatorView: View {
   let store: StoreOf<GameApp>
 
   var body: some View {
-    WithViewStore(store, observe: \.isLoggedIn) { viewStore in
+    WithPerceptionTracking {
       VStack {
-        if viewStore.state {
+        if store.isLoggedIn {
           GameCoordinatorView(store: store.scope(state: \.game, action: \.game))
             .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
         } else {
@@ -18,13 +18,14 @@ struct AppCoordinatorView: View {
             .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
         }
       }
-      .animation(.default, value: viewStore.state)
+      .animation(.default, value: store.isLoggedIn)
     }
   }
 }
 
 @Reducer
-struct GameApp: Reducer {
+struct GameApp {
+  @ObservableState
   struct State: Equatable {
     static let initialState = State(logIn: .initialState, game: .initialState(), isLoggedIn: false)
 

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameCoordinator.swift
@@ -6,7 +6,7 @@ struct GameCoordinatorView: View {
   let store: StoreOf<GameCoordinator>
 
   var body: some View {
-    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
       switch screen.case {
       case let .game(store):
         GameView(store: store)

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameCoordinator.swift
@@ -6,43 +6,18 @@ struct GameCoordinatorView: View {
   let store: StoreOf<GameCoordinator>
 
   var body: some View {
-    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
-      SwitchStore(screen) { screen in
-        switch screen {
-        case .game:
-          CaseLet(
-            \GameScreen.State.game,
-            action: GameScreen.Action.game,
-            then: GameView.init
-          )
-        }
+    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+      switch screen.case {
+      case let .game(store):
+        GameView(store: store)
       }
     }
   }
 }
 
-@Reducer
-struct GameScreen {
-  enum State: Equatable, Identifiable {
-    case game(Game.State)
-
-    var id: UUID {
-      switch self {
-      case let .game(state):
-        return state.id
-      }
-    }
-  }
-
-  enum Action {
-    case game(Game.Action)
-  }
-
-  var body: some ReducerOf<Self> {
-    Scope(state: \.game, action: \.game) {
-      Game()
-    }
-  }
+@Reducer(state: .equatable)
+enum GameScreen {
+  case game(Game)
 }
 
 @Reducer
@@ -63,8 +38,6 @@ struct GameCoordinator {
 
   var body: some ReducerOf<Self> {
     EmptyReducer()
-      .forEachRoute(\.routes, action: \.router) {
-        GameScreen()
-      }
+      .forEachRoute(\.routes, action: \.router)
   }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameView.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameView.swift
@@ -10,11 +10,11 @@ struct GameView: UIViewControllerRepresentable {
 
   typealias UIViewControllerType = GameViewController
 
-  func makeUIViewController(context: Context) -> GameViewController {
-    GameViewController(store: self.store)
+  func makeUIViewController(context _: Context) -> GameViewController {
+    GameViewController(store: store)
   }
 
-  func updateUIViewController(_ uiViewController: GameViewController, context: Context) {}
+  func updateUIViewController(_: GameViewController, context _: Context) {}
 }
 
 final class GameViewController: UIViewController {
@@ -27,56 +27,52 @@ final class GameViewController: UIViewController {
   }
 
   @available(*, unavailable)
-  required init?(coder: NSCoder) {
+  required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    self.navigationItem.title = "Tic-Tac-Toe"
-    self.view.backgroundColor = .systemBackground
+    navigationItem.title = "Tic-Tac-Toe"
+    view.backgroundColor = .systemBackground
 
-    self.navigationItem.leftBarButtonItem = UIBarButtonItem(
+    navigationItem.leftBarButtonItem = UIBarButtonItem(
       title: "Quit",
       style: .done,
       target: self,
-      action: #selector(self.quitButtonTapped)
+      action: #selector(quitButtonTapped)
     )
 
     let titleLabel = UILabel()
     titleLabel.textAlignment = .center
 
-    let playAgainButton = UIButton(type: .system)
-    playAgainButton.setTitle("Play again?", for: .normal)
-    playAgainButton.addTarget(self, action: #selector(self.playAgainButtonTapped), for: .touchUpInside)
-
     let logOutButton = UIButton(type: .system)
     logOutButton.setTitle("Log out", for: .normal)
-    logOutButton.addTarget(self, action: #selector(self.logOutButtonTapped), for: .touchUpInside)
+    logOutButton.addTarget(self, action: #selector(logOutButtonTapped), for: .touchUpInside)
 
-    let titleStackView = UIStackView(arrangedSubviews: [titleLabel, playAgainButton, logOutButton])
+    let titleStackView = UIStackView(arrangedSubviews: [titleLabel, logOutButton])
     titleStackView.axis = .vertical
     titleStackView.spacing = 2
 
     let gridCell11 = UIButton()
-    gridCell11.addTarget(self, action: #selector(self.gridCell11Tapped), for: .touchUpInside)
+    gridCell11.addTarget(self, action: #selector(gridCell11Tapped), for: .touchUpInside)
     let gridCell21 = UIButton()
-    gridCell21.addTarget(self, action: #selector(self.gridCell21Tapped), for: .touchUpInside)
+    gridCell21.addTarget(self, action: #selector(gridCell21Tapped), for: .touchUpInside)
     let gridCell31 = UIButton()
-    gridCell31.addTarget(self, action: #selector(self.gridCell31Tapped), for: .touchUpInside)
+    gridCell31.addTarget(self, action: #selector(gridCell31Tapped), for: .touchUpInside)
     let gridCell12 = UIButton()
-    gridCell12.addTarget(self, action: #selector(self.gridCell12Tapped), for: .touchUpInside)
+    gridCell12.addTarget(self, action: #selector(gridCell12Tapped), for: .touchUpInside)
     let gridCell22 = UIButton()
-    gridCell22.addTarget(self, action: #selector(self.gridCell22Tapped), for: .touchUpInside)
+    gridCell22.addTarget(self, action: #selector(gridCell22Tapped), for: .touchUpInside)
     let gridCell32 = UIButton()
-    gridCell32.addTarget(self, action: #selector(self.gridCell32Tapped), for: .touchUpInside)
+    gridCell32.addTarget(self, action: #selector(gridCell32Tapped), for: .touchUpInside)
     let gridCell13 = UIButton()
-    gridCell13.addTarget(self, action: #selector(self.gridCell13Tapped), for: .touchUpInside)
+    gridCell13.addTarget(self, action: #selector(gridCell13Tapped), for: .touchUpInside)
     let gridCell23 = UIButton()
-    gridCell23.addTarget(self, action: #selector(self.gridCell23Tapped), for: .touchUpInside)
+    gridCell23.addTarget(self, action: #selector(gridCell23Tapped), for: .touchUpInside)
     let gridCell33 = UIButton()
-    gridCell33.addTarget(self, action: #selector(self.gridCell33Tapped), for: .touchUpInside)
+    gridCell33.addTarget(self, action: #selector(gridCell33Tapped), for: .touchUpInside)
 
     let cells = [
       [gridCell11, gridCell12, gridCell13],
@@ -109,12 +105,12 @@ final class GameViewController: UIViewController {
     rootStackView.axis = .vertical
     rootStackView.spacing = 100
 
-    self.view.addSubview(rootStackView)
+    view.addSubview(rootStackView)
 
     NSLayoutConstraint.activate([
-      rootStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-      rootStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-      rootStackView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+      rootStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      rootStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      rootStackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
     ])
 
     gameStackView.arrangedSubviews
@@ -127,13 +123,11 @@ final class GameViewController: UIViewController {
         ])
       }
 
-    self.observationToken = observe { [weak self] in
+    observationToken = observe { [weak self] in
       guard let self else { return }
 
       titleLabel.text = store.title
-      playAgainButton.isHidden = store.isPlayAgainButtonHidden
-      logOutButton.isHidden = store.isPlayAgainButtonHidden
-      
+
       for (rowIdx, row) in store.gameBoard.enumerated() {
         for (colIdx, label) in row.enumerated() {
           let button = cells[rowIdx][colIdx]
@@ -183,9 +177,9 @@ struct Game {
     }
 
     var currentPlayerName: String {
-      switch self.currentPlayer {
-      case .o: return self.oPlayerName
-      case .x: return self.xPlayerName
+      switch currentPlayer {
+      case .o: return oPlayerName
+      case .x: return xPlayerName
       }
     }
   }
@@ -195,6 +189,7 @@ struct Game {
     case playAgainButtonTapped
     case logOutButtonTapped
     case quitButtonTapped
+    case gameCompleted(winner: Player?)
   }
 
   var body: some ReducerOf<Self> {
@@ -212,13 +207,19 @@ struct Game {
           state.currentPlayer.toggle()
         }
 
+        if state.board.hasWinner || state.board.isFilled {
+          return .run { [winner = state.board.winner] send in
+            await send(.gameCompleted(winner: winner))
+          }
+        }
+
         return .none
 
       case .playAgainButtonTapped:
         state = Game.State(oPlayerName: state.oPlayerName, xPlayerName: state.xPlayerName)
         return .none
 
-      case .quitButtonTapped, .logOutButtonTapped:
+      case .quitButtonTapped, .logOutButtonTapped, .gameCompleted:
         return .none
       }
     }
@@ -238,11 +239,11 @@ struct Three<Element>: CustomStringConvertible {
   }
 
   func map<T>(_ transform: (Element) -> T) -> Three<T> {
-    .init(transform(self.first), transform(self.second), transform(self.third))
+    .init(transform(first), transform(second), transform(third))
   }
 
   var description: String {
-    "[\(self.first),\(self.second),\(self.third)]"
+    "[\(first),\(second),\(third)]"
   }
 }
 
@@ -303,11 +304,15 @@ extension Three where Element == Three<Player?> {
   )
 
   var isFilled: Bool {
-    self.allSatisfy { $0.allSatisfy { $0 != nil } }
+    allSatisfy { $0.allSatisfy { $0 != nil } }
+  }
+
+  var winner: Player? {
+    if hasWin(.o) { .o } else if hasWin(.x) { .x } else { nil }
   }
 
   var hasWinner: Bool {
-    self.hasWin(.o) || self.hasWin(.x)
+    hasWin(.o) || hasWin(.x)
   }
 
   func hasWin(_ player: Player) -> Bool {

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameViewState.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameViewState.swift
@@ -7,17 +7,7 @@ extension Game.State {
     !board.hasWinner && !board.isFilled
   }
 
-  var isPlayAgainButtonHidden: Bool {
-    !board.hasWinner && !board.isFilled
-  }
-
   var title: String {
-    if board.hasWinner {
-      "Winner! Congrats \(currentPlayerName)"
-    } else if board.isFilled {
-      "Tied game!"
-    } else {
-      "\(currentPlayerName), place your \(currentPlayer.label)"
-    }
+    "\(currentPlayerName), place your \(currentPlayer.label)"
   }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameViewState.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameViewState.swift
@@ -1,0 +1,23 @@
+extension Game.State {
+  var gameBoard: Three<Three<String>> {
+    board.map { $0.map { $0?.label ?? "" } }
+  }
+
+  var isGameEnabled: Bool {
+    !board.hasWinner && !board.isFilled
+  }
+
+  var isPlayAgainButtonHidden: Bool {
+    !board.hasWinner && !board.isFilled
+  }
+
+  var title: String {
+    if board.hasWinner {
+      "Winner! Congrats \(currentPlayerName)"
+    } else if board.isFilled {
+      "Tied game!"
+    } else {
+      "\(currentPlayerName), place your \(currentPlayer.label)"
+    }
+  }
+}

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift
@@ -12,7 +12,7 @@ struct LogInCoordinatorView: View {
   let store: StoreOf<LogInCoordinator>
 
   var body: some View {
-    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
       switch screen.case {
       case let .welcome(store):
         WelcomeView(store: store)

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift
@@ -2,65 +2,31 @@ import ComposableArchitecture
 import SwiftUI
 import TCACoordinators
 
-@Reducer
-struct LogInScreen {
-  enum Action {
-    case welcome(Welcome.Action)
-    case logIn(LogIn.Action)
-  }
-
-  enum State: Equatable, Identifiable {
-    case welcome(Welcome.State)
-    case logIn(LogIn.State)
-
-    var id: UUID {
-      switch self {
-      case let .welcome(state):
-        state.id
-      case let .logIn(state):
-        state.id
-      }
-    }
-  }
-
-  var body: some ReducerOf<Self> {
-    Scope(state: \.welcome, action: \.welcome) {
-      Welcome()
-    }
-    Scope(state: \.logIn, action: \.logIn) {
-      LogIn()
-    }
-  }
+@Reducer(state: .equatable)
+enum LogInScreen {
+  case welcome(Welcome)
+  case logIn(LogIn)
 }
 
 struct LogInCoordinatorView: View {
   let store: StoreOf<LogInCoordinator>
 
   var body: some View {
-    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
-      SwitchStore(screen) { screen in
-        switch screen {
-        case .welcome:
-          CaseLet(
-            \LogInScreen.State.welcome,
-            action: LogInScreen.Action.welcome,
-            then: WelcomeView.init
-          )
+    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+      switch screen.case {
+      case let .welcome(store):
+        WelcomeView(store: store)
 
-        case .logIn:
-          CaseLet(
-            \LogInScreen.State.logIn,
-            action: LogInScreen.Action.logIn,
-            then: LogInView.init
-          )
-        }
+      case let .logIn(store):
+        LogInView(store: store)
       }
     }
   }
 }
 
 @Reducer
-struct LogInCoordinator: Reducer {
+struct LogInCoordinator {
+  @ObservableState
   struct State: Equatable {
     static let initialState = LogInCoordinator.State(
       routes: [.root(.welcome(.init()), embedInNavigationView: true)]
@@ -83,8 +49,6 @@ struct LogInCoordinator: Reducer {
       }
       return .none
     }
-    .forEachRoute(\.routes, action: \.router) {
-      LogInScreen()
-    }
+    .forEachRoute(\.routes, action: \.router)
   }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInScreen+StateIdentifiable.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInScreen+StateIdentifiable.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension LogInScreen.State: Identifiable {
+  var id: UUID {
+    switch self {
+    case let .welcome(state):
+      state.id
+    case let .logIn(state):
+      state.id
+    }
+  }
+}

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInView.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInView.swift
@@ -20,16 +20,13 @@ struct LogInView: View {
   }
 }
 
-struct LogIn: Reducer {
+@Reducer
+struct LogIn {
   struct State: Equatable {
     let id = UUID()
   }
 
   enum Action {
     case logInTapped(name: String)
-  }
-
-  var body: some ReducerOf<Self> {
-    EmptyReducer()
   }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/OutcomeView.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/OutcomeView.swift
@@ -1,0 +1,45 @@
+import Combine
+import ComposableArchitecture
+import SwiftUI
+import UIKit
+
+struct OutcomeView: View {
+  let store: StoreOf<Outcome>
+
+  var body: some View {
+    WithPerceptionTracking {
+      VStack {
+        if let winner = store.winnerName {
+          Text("Congratulations \(winner)!")
+        } else {
+          Text("The game ended in a draw")
+        }
+        Button("New game") {
+          store.send(.newGameTapped)
+        }
+      }
+      .navigationTitle("Game over")
+      .navigationBarBackButtonHidden()
+    }
+  }
+}
+
+@Reducer
+struct Outcome {
+  @ObservableState
+  struct State: Equatable {
+    let id = UUID()
+    var winner: Player?
+    var oPlayerName: String
+    var xPlayerName: String
+
+    var winnerName: String? {
+      guard let winner = winner else { return nil }
+      return winner == .x ? xPlayerName : oPlayerName
+    }
+  }
+
+  enum Action: Equatable {
+    case newGameTapped
+  }
+}

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/WelcomeView.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/WelcomeView.swift
@@ -16,16 +16,13 @@ struct WelcomeView: View {
   }
 }
 
-struct Welcome: Reducer {
+@Reducer
+struct Welcome {
   struct State: Equatable {
     let id = UUID()
   }
 
   enum Action {
     case logInTapped
-  }
-
-  var body: some ReducerOf<Self> {
-    EmptyReducer()
   }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
@@ -6,18 +6,16 @@ struct IdentifiedCoordinatorView: View {
   @State var store: StoreOf<IdentifiedCoordinator>
 
   var body: some View {
-    WithPerceptionTracking {
-      ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
-        switch screen.case {
-        case let .home(store):
-          HomeView(store: store)
+    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+      switch screen.case {
+      case let .home(store):
+        HomeView(store: store)
 
-        case let .numbersList(store):
-          NumbersListView(store: store)
+      case let .numbersList(store):
+        NumbersListView(store: store)
 
-        case let .numberDetail(store):
-          NumberDetailView(store: store)
-        }
+      case let .numberDetail(store):
+        NumberDetailView(store: store)
       }
     }
   }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
@@ -6,7 +6,7 @@ struct IdentifiedCoordinatorView: View {
   @State var store: StoreOf<IdentifiedCoordinator>
 
   var body: some View {
-    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
       switch screen.case {
       case let .home(store):
         HomeView(store: store)

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
@@ -85,8 +85,6 @@ struct IdentifiedCoordinator: Reducer {
       }
       return .none
     }
-    .forEachRoute(\.routes, action: \.router) {
-      Screen.body
-    }
+    .forEachRoute(\.routes, action: \.router)
   }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
@@ -3,53 +3,53 @@ import SwiftUI
 import TCACoordinators
 
 struct IdentifiedCoordinatorView: View {
-	@State var store: StoreOf<IdentifiedCoordinator>
+  @State var store: StoreOf<IdentifiedCoordinator>
 
-	var body: some View {
-		WithPerceptionTracking {
-			ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
-				switch screen.case {
-				case let .home(store):
-					HomeView(store: store)
+  var body: some View {
+    WithPerceptionTracking {
+      ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+        switch screen.case {
+        case let .home(store):
+          HomeView(store: store)
 
-				case let .numbersList(store):
-					NumbersListView(store: store)
+        case let .numbersList(store):
+          NumbersListView(store: store)
 
-				case let .numberDetail(store):
-					NumberDetailView(store: store)
-				}
-			}
-		}
-	}
+        case let .numberDetail(store):
+          NumberDetailView(store: store)
+        }
+      }
+    }
+  }
 }
 
 extension Screen.State: Identifiable {
-	var id: UUID {
-		switch self {
-		case .home(let state):
-			return state.id
-		case .numbersList(let state):
-			return state.id
-		case .numberDetail(let state):
-			return state.id
-		}
-	}
+  var id: UUID {
+    switch self {
+    case let .home(state):
+      return state.id
+    case let .numbersList(state):
+      return state.id
+    case let .numberDetail(state):
+      return state.id
+    }
+  }
 }
 
 @Reducer
 struct IdentifiedCoordinator: Reducer {
-	enum Deeplink {
-		case showNumber(Int)
-	}
+  enum Deeplink {
+    case showNumber(Int)
+  }
 
-	@ObservableState
-	struct State: Equatable {
-		static let initialState = State(
-			routes: [.root(.home(.init()), embedInNavigationView: true)]
-		)
+  @ObservableState
+  struct State: Equatable {
+    static let initialState = State(
+      routes: [.root(.home(.init()), embedInNavigationView: true)]
+    )
 
-		var routes: IdentifiedArrayOf<Route<Screen.State>>
-	}
+    var routes: IdentifiedArrayOf<Route<Screen.State>>
+  }
 
   enum Action {
     case router(IdentifiedRouterActionOf<Screen>)
@@ -75,18 +75,18 @@ struct IdentifiedCoordinator: Reducer {
           $0.goBackTo(\.numbersList)
         }
 
-			case .router(.routeAction(_, .numberDetail(.goBackToRootTapped))):
-				return .routeWithDelaysIfUnsupported(state.routes, action: \.router, scheduler: .main) {
-					$0.goBackToRoot()
-				}
+      case .router(.routeAction(_, .numberDetail(.goBackToRootTapped))):
+        return .routeWithDelaysIfUnsupported(state.routes, action: \.router, scheduler: .main) {
+          $0.goBackToRoot()
+        }
 
-			default:
-				break
-			}
-			return .none
-		}
-		.forEachRoute(\.routes, action: \.router) {
-			Screen.body
-		}
-	}
+      default:
+        break
+      }
+      return .none
+    }
+    .forEachRoute(\.routes, action: \.router) {
+      Screen.body
+    }
+  }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IdentifiedCoordinator.swift
@@ -35,7 +35,7 @@ extension Screen.State: Identifiable {
 }
 
 @Reducer
-struct IdentifiedCoordinator: Reducer {
+struct IdentifiedCoordinator {
   enum Deeplink {
     case showNumber(Int)
   }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IndexedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IndexedCoordinator.swift
@@ -6,7 +6,7 @@ struct IndexedCoordinatorView: View {
   @State var store: StoreOf<IndexedCoordinator>
 
   var body: some View {
-    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+    TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
       switch screen.case {
       case let .home(store):
         HomeView(store: store)

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IndexedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IndexedCoordinator.swift
@@ -6,18 +6,16 @@ struct IndexedCoordinatorView: View {
   @State var store: StoreOf<IndexedCoordinator>
 
   var body: some View {
-    WithPerceptionTracking {
-      ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
-        switch screen.case {
-        case let .home(store):
-          HomeView(store: store)
+    ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+      switch screen.case {
+      case let .home(store):
+        HomeView(store: store)
 
-        case let .numbersList(store):
-          NumbersListView(store: store)
+      case let .numbersList(store):
+        NumbersListView(store: store)
 
-        case let .numberDetail(store):
-          NumberDetailView(store: store)
-        }
+      case let .numberDetail(store):
+        NumberDetailView(store: store)
       }
     }
   }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IndexedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IndexedCoordinator.swift
@@ -3,36 +3,36 @@ import SwiftUI
 import TCACoordinators
 
 struct IndexedCoordinatorView: View {
-	@State var store: StoreOf<IndexedCoordinator>
+  @State var store: StoreOf<IndexedCoordinator>
 
-	var body: some View {
-		WithPerceptionTracking {
-			ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
-				switch screen.case {
-				case let .home(store):
-					HomeView(store: store)
+  var body: some View {
+    WithPerceptionTracking {
+      ObservedTCARouter(store.scope(state: \.routes, action: \.router)) { screen in
+        switch screen.case {
+        case let .home(store):
+          HomeView(store: store)
 
-				case let .numbersList(store):
-					NumbersListView(store: store)
+        case let .numbersList(store):
+          NumbersListView(store: store)
 
-				case let .numberDetail(store):
-					NumberDetailView(store: store)
-				}
-			}
-		}
-	}
+        case let .numberDetail(store):
+          NumberDetailView(store: store)
+        }
+      }
+    }
+  }
 }
 
 @Reducer
 struct IndexedCoordinator {
-	@ObservableState
-	struct State: Equatable {
-		static let initialState = State(
-			routes: [.root(.home(.init()), embedInNavigationView: true)]
-		)
+  @ObservableState
+  struct State: Equatable {
+    static let initialState = State(
+      routes: [.root(.home(.init()), embedInNavigationView: true)]
+    )
 
-		var routes: [Route<Screen.State>]
-	}
+    var routes: [Route<Screen.State>]
+  }
 
   enum Action {
     case router(IndexedRouterActionOf<Screen>)
@@ -58,18 +58,18 @@ struct IndexedCoordinator {
           $0.goBackTo(\.numbersList)
         }
 
-			case .router(.routeAction(_, .numberDetail(.goBackToRootTapped))):
-				return .routeWithDelaysIfUnsupported(state.routes, action: \.router) {
-					$0.goBackToRoot()
-				}
+      case .router(.routeAction(_, .numberDetail(.goBackToRootTapped))):
+        return .routeWithDelaysIfUnsupported(state.routes, action: \.router) {
+          $0.goBackToRoot()
+        }
 
-			default:
-				break
-			}
-			return .none
-		}
-		.forEachRoute(\.routes, action: \.router) {
-			Screen.body
-		}
-	}
+      default:
+        break
+      }
+      return .none
+    }
+    .forEachRoute(\.routes, action: \.router) {
+      Screen.body
+    }
+  }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/IndexedCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/IndexedCoordinator.swift
@@ -68,8 +68,6 @@ struct IndexedCoordinator {
       }
       return .none
     }
-    .forEachRoute(\.routes, action: \.router) {
-      Screen.body
-    }
+    .forEachRoute(\.routes, action: \.router)
   }
 }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
@@ -83,13 +83,13 @@ struct NumberDetailView: View {
         Button("Increment after delay") {
           store.send(.incrementAfterDelayTapped)
         }
-        Button("Show double") {
+        Button("Show double (\(store.number * 2))") {
           store.send(.showDouble(store.number))
         }
         Button("Go back") {
           store.send(.goBackTapped)
         }
-        Button("Go back to root") {
+        Button("Go back to root from \(store.number)") {
           store.send(.goBackToRootTapped)
         }
         Button("Go back to numbers list") {

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
@@ -2,43 +2,50 @@ import ComposableArchitecture
 import Foundation
 import SwiftUI
 
-@Reducer
-struct Screen: Reducer {
-  enum Action {
-    case home(Home.Action)
-    case numbersList(NumbersList.Action)
-    case numberDetail(NumberDetail.Action)
-  }
-
-  enum State: Equatable, Identifiable {
-    case home(Home.State)
-    case numbersList(NumbersList.State)
-    case numberDetail(NumberDetail.State)
-
-    var id: UUID {
-      switch self {
-      case let .home(state):
-        return state.id
-      case let .numbersList(state):
-        return state.id
-      case let .numberDetail(state):
-        return state.id
-      }
-    }
-  }
-
-  var body: some ReducerOf<Self> {
-    Scope(state: \.home, action: \.home) {
-      Home()
-    }
-    Scope(state: \.numbersList, action: \.numbersList) {
-      NumbersList()
-    }
-    Scope(state: \.numberDetail, action: \.numberDetail) {
-      NumberDetail()
-    }
-  }
+@Reducer(state: .equatable)
+enum Screen {
+	case home(Home)
+	case numbersList(NumbersList)
+	case numberDetail(NumberDetail)
 }
+
+//@Reducer
+//struct Screen: Reducer {
+//  enum Action {
+//    case home(Home.Action)
+//    case numbersList(NumbersList.Action)
+//    case numberDetail(NumberDetail.Action)
+//  }
+//
+//  enum State: Equatable, Identifiable {
+//    case home(Home.State)
+//    case numbersList(NumbersList.State)
+//    case numberDetail(NumberDetail.State)
+//
+//    var id: UUID {
+//      switch self {
+//      case .home(let state):
+//        return state.id
+//      case .numbersList(let state):
+//        return state.id
+//      case .numberDetail(let state):
+//        return state.id
+//      }
+//    }
+//  }
+//
+//  var body: some ReducerOf<Self> {
+//    Scope(state: \.home, action: \.home) {
+//      Home()
+//    }
+//    Scope(state: \.numbersList, action: \.numbersList) {
+//      NumbersList()
+//    }
+//    Scope(state: \.numberDetail, action: \.numberDetail) {
+//      NumberDetail()
+//    }
+//  }
+//}
 
 // Home
 

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
@@ -24,17 +24,14 @@ struct HomeView: View {
   }
 }
 
-struct Home: Reducer {
+@Reducer
+struct Home {
   struct State: Equatable {
     let id = UUID()
   }
 
   enum Action {
     case startTapped
-  }
-
-  var body: some ReducerOf<Self> {
-    EmptyReducer()
   }
 }
 
@@ -44,12 +41,12 @@ struct NumbersListView: View {
   let store: StoreOf<NumbersList>
 
   var body: some View {
-    WithViewStore(store, observe: \.numbers) { viewStore in
-      List(viewStore.state, id: \.self) { number in
+    WithPerceptionTracking {
+      List(store.numbers, id: \.self) { number in
         Button(
           "\(number)",
           action: {
-            viewStore.send(.numberSelected(number))
+            store.send(.numberSelected(number))
           }
         )
       }
@@ -58,7 +55,9 @@ struct NumbersListView: View {
   }
 }
 
-struct NumbersList: Reducer {
+@Reducer
+struct NumbersList {
+  @ObservableState
   struct State: Equatable {
     let id = UUID()
     let numbers: [Int]
@@ -66,10 +65,6 @@ struct NumbersList: Reducer {
 
   enum Action {
     case numberSelected(Int)
-  }
-
-  var body: some ReducerOf<Self> {
-    EmptyReducer()
   }
 }
 
@@ -79,35 +74,36 @@ struct NumberDetailView: View {
   let store: StoreOf<NumberDetail>
 
   var body: some View {
-    WithViewStore(store, observe: \.number) { viewStore in
+    WithPerceptionTracking {
       VStack(spacing: 8.0) {
-        Text("Number \(viewStore.state)")
+        Text("Number \(store.number)")
         Button("Increment") {
-          viewStore.send(.incrementTapped)
+          store.send(.incrementTapped)
         }
         Button("Increment after delay") {
-          viewStore.send(.incrementAfterDelayTapped)
+          store.send(.incrementAfterDelayTapped)
         }
         Button("Show double") {
-          viewStore.send(.showDouble(viewStore.state))
+          store.send(.showDouble(store.number))
         }
         Button("Go back") {
-          viewStore.send(.goBackTapped)
+          store.send(.goBackTapped)
         }
         Button("Go back to root") {
-          viewStore.send(.goBackToRootTapped)
+          store.send(.goBackToRootTapped)
         }
         Button("Go back to numbers list") {
-          viewStore.send(.goBackToNumbersList)
+          store.send(.goBackToNumbersList)
         }
       }
-      .navigationTitle("Number \(viewStore.state)")
+      .navigationTitle("Number \(store.number)")
     }
   }
 }
 
 @Reducer
 struct NumberDetail {
+  @ObservableState
   struct State: Equatable {
     let id = UUID()
     var number: Int

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
@@ -9,44 +9,6 @@ enum Screen {
   case numberDetail(NumberDetail)
 }
 
-// @Reducer
-// struct Screen: Reducer {
-//  enum Action {
-//    case home(Home.Action)
-//    case numbersList(NumbersList.Action)
-//    case numberDetail(NumberDetail.Action)
-//  }
-//
-//  enum State: Equatable, Identifiable {
-//    case home(Home.State)
-//    case numbersList(NumbersList.State)
-//    case numberDetail(NumberDetail.State)
-//
-//    var id: UUID {
-//      switch self {
-//      case .home(let state):
-//        return state.id
-//      case .numbersList(let state):
-//        return state.id
-//      case .numberDetail(let state):
-//        return state.id
-//      }
-//    }
-//  }
-//
-//  var body: some ReducerOf<Self> {
-//    Scope(state: \.home, action: \.home) {
-//      Home()
-//    }
-//    Scope(state: \.numbersList, action: \.numbersList) {
-//      NumbersList()
-//    }
-//    Scope(state: \.numberDetail, action: \.numberDetail) {
-//      NumberDetail()
-//    }
-//  }
-// }
-
 // Home
 
 struct HomeView: View {

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
@@ -4,13 +4,13 @@ import SwiftUI
 
 @Reducer(state: .equatable)
 enum Screen {
-	case home(Home)
-	case numbersList(NumbersList)
-	case numberDetail(NumberDetail)
+  case home(Home)
+  case numbersList(NumbersList)
+  case numberDetail(NumberDetail)
 }
 
-//@Reducer
-//struct Screen: Reducer {
+// @Reducer
+// struct Screen: Reducer {
 //  enum Action {
 //    case home(Home.Action)
 //    case numbersList(NumbersList.Action)
@@ -45,7 +45,7 @@ enum Screen {
 //      NumberDetail()
 //    }
 //  }
-//}
+// }
 
 // Home
 

--- a/TCACoordinatorsExample/TCACoordinatorsExample/TCACoordinatorsExampleApp.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/TCACoordinatorsExampleApp.swift
@@ -18,11 +18,11 @@ struct TCACoordinatorsExampleApp: App {
 // MainTabCoordinator
 
 struct MainTabCoordinatorView: View {
-  let store: StoreOf<MainTabCoordinator>
+  @Perception.Bindable var store: StoreOf<MainTabCoordinator>
 
   var body: some View {
-    WithViewStore(store, observe: \.selectedTab) { viewStore in
-      TabView(selection: viewStore.binding(get: { $0 }, send: MainTabCoordinator.Action.tabSelected)) {
+    WithPerceptionTracking {
+      TabView(selection: $store.selectedTab.sending(\.tabSelected)) {
         IndexedCoordinatorView(
           store: store.scope(
             state: \.indexed,
@@ -62,7 +62,7 @@ struct MainTabCoordinatorView: View {
       }.onOpenURL { _ in
         // In reality, the URL would be parsed into a Deeplink.
         let deeplink = MainTabCoordinator.Deeplink.identified(.showNumber(42))
-        viewStore.send(.deeplinkOpened(deeplink))
+        store.send(.deeplinkOpened(deeplink))
       }
     }
   }
@@ -87,6 +87,7 @@ struct MainTabCoordinator: Reducer {
     case tabSelected(Tab)
   }
 
+  @ObservableState
   struct State: Equatable {
     static let initialState = State(
       identified: .initialState,

--- a/TCACoordinatorsExample/TCACoordinatorsExample/TCACoordinatorsExampleApp.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/TCACoordinatorsExampleApp.swift
@@ -69,7 +69,7 @@ struct MainTabCoordinatorView: View {
 }
 
 @Reducer
-struct MainTabCoordinator: Reducer {
+struct MainTabCoordinator {
   enum Tab: Hashable {
     case identified, indexed, app, form, deeplinkOpened
   }

--- a/TCACoordinatorsExample/TCACoordinatorsExampleUITests/TCACoordinatorsExampleUITests.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExampleUITests/TCACoordinatorsExampleUITests.swift
@@ -29,13 +29,35 @@ class TCACoordinatorsExampleUITests: XCTestCase {
     XCTAssertTrue(app.navigationBars["Number 2"].waitForExistence(timeout: navigationTimeout))
 
     app.buttons["Increment after delay"].tap()
-    app.buttons["Show double"].tap()
+    app.buttons["Show double (4)"].tap()
     XCTAssertTrue(app.navigationBars["Number 4"].waitForExistence(timeout: navigationTimeout))
 
     // Ensures increment will have happened off-screen.
     Thread.sleep(forTimeInterval: 3)
 
-    app.navigationBars["Number 4"].swipeDown(velocity: .fast)
+    app.navigationBars["Number 4"].swipeSheetDown()
     XCTAssertTrue(app.navigationBars["Number 3"].waitForExistence(timeout: navigationTimeout))
+
+    app.buttons["Show double (6)"].tap()
+    XCTAssertTrue(app.navigationBars["Number 6"].waitForExistence(timeout: navigationTimeout))
+
+    app.buttons["Show double (12)"].tap()
+    XCTAssertTrue(app.navigationBars["Number 12"].waitForExistence(timeout: navigationTimeout))
+
+    app.buttons["Go back to root from 12"].tap()
+    XCTAssertTrue(app.navigationBars["Home"].waitForExistence(timeout: navigationTimeout * 3))
+  }
+}
+
+extension XCUIElement {
+  func swipeSheetDown() {
+    if #available(iOS 17.0, *) {
+      // This doesn't work in iOS 16
+      self.swipeDown(velocity: .fast)
+    } else {
+      let start = coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8))
+      let end = coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 5))
+      start.press(forDuration: 0.05, thenDragTo: end, withVelocity: .fast, thenHoldForDuration: 0.0)
+    }
   }
 }

--- a/Tests/TCACoordinatorsTests/IdentifiedRouterTests.swift
+++ b/Tests/TCACoordinatorsTests/IdentifiedRouterTests.swift
@@ -2,8 +2,8 @@ import ComposableArchitecture
 @testable import TCACoordinators
 import XCTest
 
-@MainActor
 final class IdentifiedRouterTests: XCTestCase {
+  @MainActor
   func testActionPropagation() async {
     let scheduler = DispatchQueue.test
     let store = TestStore(
@@ -24,6 +24,7 @@ final class IdentifiedRouterTests: XCTestCase {
     }
   }
 
+  @MainActor
   func testActionCancellation() async {
     let scheduler = DispatchQueue.test
     let store = TestStore(
@@ -51,6 +52,7 @@ final class IdentifiedRouterTests: XCTestCase {
   }
 
   @available(iOS 16.0, *)
+  @MainActor
   func testWithDelaysIfUnsupported() async throws {
     let initialRoutes: IdentifiedArrayOf<Route<Child.State>> = [
       .root(.init(id: "first", count: 1)),

--- a/Tests/TCACoordinatorsTests/IdentifiedRouterTests.swift
+++ b/Tests/TCACoordinatorsTests/IdentifiedRouterTests.swift
@@ -77,7 +77,7 @@ final class IdentifiedRouterTests: XCTestCase {
 }
 
 @Reducer
-private struct Child: Reducer {
+private struct Child {
   let scheduler: TestSchedulerOf<DispatchQueue>
   struct State: Equatable, Identifiable {
     var id: String
@@ -106,7 +106,7 @@ private struct Child: Reducer {
 }
 
 @Reducer
-private struct Parent: Reducer {
+private struct Parent {
   let scheduler: TestSchedulerOf<DispatchQueue>
   struct State: Equatable {
     var routes: IdentifiedArrayOf<Route<Child.State>>

--- a/Tests/TCACoordinatorsTests/IndexedRouterTests.swift
+++ b/Tests/TCACoordinatorsTests/IndexedRouterTests.swift
@@ -2,8 +2,8 @@ import ComposableArchitecture
 @testable import TCACoordinators
 import XCTest
 
-@MainActor
 final class IndexedRouterTests: XCTestCase {
+  @MainActor
   func testActionPropagation() async {
     let scheduler = DispatchQueue.test
     let store = TestStore(
@@ -25,6 +25,7 @@ final class IndexedRouterTests: XCTestCase {
     }
   }
 
+  @MainActor
   func testActionCancellation() async {
     let scheduler = DispatchQueue.test
     let store = TestStore(
@@ -52,6 +53,7 @@ final class IndexedRouterTests: XCTestCase {
   }
 
   @available(iOS 16.0, *)
+  @MainActor
   func testWithDelaysIfUnsupported() async throws {
     let initialRoutes: [Route<Child.State>] = [
       .root(.init(count: 1)),

--- a/Tests/TCACoordinatorsTests/IndexedRouterTests.swift
+++ b/Tests/TCACoordinatorsTests/IndexedRouterTests.swift
@@ -78,7 +78,7 @@ final class IndexedRouterTests: XCTestCase {
 }
 
 @Reducer
-private struct Child: Reducer {
+private struct Child {
   let scheduler: TestSchedulerOf<DispatchQueue>
   struct State: Equatable {
     var count = 0
@@ -106,7 +106,7 @@ private struct Child: Reducer {
 }
 
 @Reducer
-private struct Parent: Reducer {
+private struct Parent {
   struct State: Equatable {
     var routes: [Route<Child.State>]
   }


### PR DESCRIPTION
An initial attempt at adding Observation to TCACoordinators

I've updated all the sample code to use the `@Reducer` macro, and for the screen reducers, I've migrated them to `@Reducer(state: .equatable)` where appropriate. This has reduced the amount of code needed to maintain these features, and they seems to work as before! I've even updated the UIKit example to use Observation.

This particular iteration of the work separates out the ObservedTCARouter from the normal TCARouter, but I think your patch should still be applicable over this work!

Also, just to note - there's a bit of additional work going on in the GameCoordinator that I'm not sure is super necessary. I think the entire GameCoordinator can probably be pared back so the `AppCoordinatorView` literally just switches between `GameView` and `LogInCoordinatorView` – what do you think?