### PR TITLE
Fix issue 73

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-          "version": "1.0.0"
+          "revision": "5928286acce13def418ec36d05a001a9641086f2",
+          "version": "1.0.3"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/johnpatrickmorgan/FlowStacks",
         "state": {
           "branch": null,
-          "revision": "468de8179d68f9e150ffafcb4574dee52dfa3976",
-          "version": "0.4.0"
+          "revision": "a2b974b81612e1e8ee3ecd757d936a2919527356",
+          "version": "0.4.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {
           "branch": null,
-          "revision": "79623dbe2c7672f5e450d8325613d231454390b3",
-          "version": "1.3.2"
+          "revision": "19b7263bacb9751f151ec0c93ec816fe1ef67c7b",
+          "version": "1.6.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-clocks",
         "state": {
           "branch": null,
-          "revision": "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
-          "version": "1.0.2"
+          "revision": "cc46202b53476d64e824e0b6612da09d84ffde8e",
+          "version": "1.0.6"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-          "version": "1.1.0"
+          "revision": "671108c96644956dddcd89dd59c203dcdb36cec7",
+          "version": "1.1.4"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture",
         "state": {
           "branch": null,
-          "revision": "115fe5af41d333b6156d4924d7c7058bc77fd580",
-          "version": "1.9.2"
+          "revision": "2ebda6ae2b155a5c3d75aff5f6d25c024bc91311",
+          "version": "1.17.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras",
         "state": {
           "branch": null,
-          "revision": "bb5059bde9022d69ac516803f4f227d8ac967f71",
-          "version": "1.1.0"
+          "revision": "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+          "version": "1.3.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
           "branch": null,
-          "revision": "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-          "version": "1.3.0"
+          "revision": "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+          "version": "1.3.3"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-dependencies",
         "state": {
           "branch": null,
-          "revision": "d3a5af3038a09add4d7682f66555d6212058a3c0",
-          "version": "1.2.2"
+          "revision": "52b5e1a09dc016e64ce253e19ab3124b7fae9ac9",
+          "version": "1.7.0"
         }
       },
       {
@@ -87,8 +87,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
         "state": {
           "branch": null,
-          "revision": "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
-          "version": "1.0.0"
+          "revision": "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "swift-navigation",
+        "repositoryURL": "https://github.com/pointfreeco/swift-navigation",
+        "state": {
+          "branch": null,
+          "revision": "e28911721538fa0c2439e92320bad13e3200866f",
+          "version": "2.2.3"
         }
       },
       {
@@ -96,26 +105,26 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-perception",
         "state": {
           "branch": null,
-          "revision": "520c458a832d1287e6b698c5f657ae848fd696ff",
-          "version": "1.1.4"
+          "revision": "21811d6230a625fa0f2e6ffa85be857075cc02c4",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "package": "swift-sharing",
+        "repositoryURL": "https://github.com/pointfreeco/swift-sharing",
+        "state": {
+          "branch": null,
+          "revision": "e4e239979e718ce52fb67ffd14ef491cede7ab43",
+          "version": "2.2.0"
         }
       },
       {
         "package": "swift-syntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax",
+        "repositoryURL": "https://github.com/swiftlang/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-          "version": "510.0.1"
-        }
-      },
-      {
-        "package": "swiftui-navigation",
-        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation",
-        "state": {
-          "branch": null,
-          "revision": "2ec6c3a15293efff6083966b38439a4004f25565",
-          "version": "1.3.0"
+          "revision": "0687f71944021d616d34d922343dcef086855920",
+          "version": "600.0.1"
         }
       },
       {
@@ -123,8 +132,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-          "version": "1.1.2"
+          "revision": "b444594f79844b0d6d76d70fbfb3f7f71728f938",
+          "version": "1.5.1"
         }
       }
     ]

--- a/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
+++ b/Sources/TCACoordinators/Reducers/ForEachIdentifiedRoute.swift
@@ -159,9 +159,9 @@ public extension Reducer {
 extension Case {
   subscript<Element: Identifiable>() -> Case<IdentifiedArray<Element.ID, Element>> where Value == [Element] {
     Case<IdentifiedArrayOf<Element>>(
-      embed: { self.embed($0.elements) },
+      embed: { self._embed($0.elements) },
       extract: {
-        self.extract(from: $0).flatMap { IdentifiedArrayOf(uniqueElements: $0) }
+        self._extract(from: $0).flatMap { IdentifiedArrayOf(uniqueElements: $0) }
       }
     )
   }
@@ -171,11 +171,11 @@ extension Case {
       embed: { action in
         switch action {
         case let .element(id, action):
-          self.embed((id, action))
+          self._embed((id, action))
         }
       },
       extract: {
-        self.extract(from: $0).flatMap {
+        self._extract(from: $0).flatMap {
           .element(id: $0, action: $1)
         }
       }


### PR DESCRIPTION
Modify `ForEachIdentifiedRoute` to work with the newest swift-case-path version (1.6.x).

```swift
// from:
self.embed($0.elements)
// to
self._embed($0.elements)
```