### PR TITLE
Update TCARouter and UnobservedTCARouter to support TCA 1.19.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "2ebda6ae2b155a5c3d75aff5f6d25c024bc91311",
-        "version" : "1.17.1"
+        "revision" : "b1d27a82b498b8e697acabd8cc01b585d26aab19",
+        "version" : "1.19.1"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "e28911721538fa0c2439e92320bad13e3200866f",
-        "version" : "2.2.3"
+        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Sources/TCACoordinators/TCARouter/TCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter.swift
@@ -24,21 +24,17 @@ public struct TCARouter<
     self.screenContent = screenContent
   }
 
-  func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
-    var screen = screen
-    let id = identifier(screen, index)
-    return store.scope(
-      id: store.id(state: \.[index], action: \.[id: id]),
-      state: ToState {
-        screen = $0[safe: index]?.screen ?? screen
-        return screen
-      },
-      action: {
-        .routeAction(id: id, action: $0)
-      },
-      isInvalid: { !$0.indices.contains(index) }
-    )
-  }
+	func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
+		let routesStore = store
+
+		return routesStore.scope(
+			state: {
+				guard $0.indices.contains(index) else { return screen }
+				return $0[index].screen
+			},
+			action: { .routeAction(id: identifier(screen, index), action: $0) }
+		)
+	}
 
   public var body: some View {
     if Screen.self is ObservableState.Type {

--- a/Sources/TCACoordinators/TCARouter/UnobservedTCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/UnobservedTCARouter.swift
@@ -26,21 +26,17 @@ struct UnobservedTCARouter<
     self.screenContent = screenContent
   }
 
-  func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
-    var screen = screen
-    let id = identifier(screen, index)
-    return store.scope(
-      id: store.id(state: \.[index], action: \.[id: id]),
-      state: ToState {
-        screen = $0[safe: index]?.screen ?? screen
-        return screen
-      },
-      action: {
-        .routeAction(id: id, action: $0)
-      },
-      isInvalid: { !$0.indices.contains(index) }
-    )
-  }
+	func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
+	  let routesStore = store
+
+	  return routesStore.scope(
+		state: {
+		  guard $0.indices.contains(index) else { return screen }
+		  return $0[index].screen
+		},
+		action: { .routeAction(id: identifier(screen, index), action: $0) }
+	  )
+	}
 
   var body: some View {
     WithViewStore(store, observe: { $0 }) { viewStore in


### PR DESCRIPTION
Hi @johnpatrickmorgan 

It would be cool to get TCACoordnator compatible with the latest version of TCA (currently 1.19.1). I use TCACoordnator which works so well by the way. Iv made an attempt to update the breaking changes. TCARouter was using an internal  `store.scope(id: state, action, isInvalid)` method. I have tried using the public `scope(state, action)` which does seem to work but I am unsure if this is indeed the correct way, there may be some technicality I might be missing as there was some internals I was not clear on what was going on.

It would be awesome if you could take a look and have your input on what needs to be done to bring TCACoordnator compatible with TCA 1.19.1. Thanks Gus