### PR TITLE
Add support for TCA 1.19.1

### DIFF
--- a/Docs/Migration/Migrating from 0.11.md
+++ b/Docs/Migration/Migrating from 0.11.md
@@ -1,0 +1,5 @@
+#  Migrating from 0.11
+
+Version 0.12 of this library introduced an API change to allow it to work with the latest version of the Composable Architecture (>=0.19). This change improves the way the routes store is scoped into individual screen stores. This change introduced a new requirement: that the screen reducer's state conform to `Hashable`. This allows for more efficient scoping using key paths.
+
+**TL;DR: the screen reducer's' state must now conform to `Hashable`.**

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "b1d27a82b498b8e697acabd8cc01b585d26aab19",
-        "version" : "1.19.1"
+        "revision" : "294ac2cbfe48a41a6bd3c294fbb7bc5f0f5194d6",
+        "version" : "1.20.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "2ebda6ae2b155a5c3d75aff5f6d25c024bc91311",
-        "version" : "1.17.1"
+        "revision" : "b1d27a82b498b8e697acabd8cc01b585d26aab19",
+        "version" : "1.19.1"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "e28911721538fa0c2439e92320bad13e3200866f",
-        "version" : "2.2.3"
+        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/johnpatrickmorgan/FlowStacks", "0.3.6" ..< "0.6.0"),
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.18.0"))
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.12.0"),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The library works by translating the array of screens into a hierarchy of nested
 First, identify all possible screens that are part of the particular navigation flow you're modelling. The goal will be to combine their reducers into a single reducer - one that can drive the behaviour of any of those screens. Thanks to the `@Reducer macro`, this can be easily achieved with an enum reducer, e.g. the following (where `Home`, `NumbersList` and `NumberDetail` are the individual screen reducers):
 
 ```swift
-@Reducer(state: .equatable)
+@Reducer(state: .hashable)
 enum Screen {
   case home(Home)
   case numbersList(NumbersList)
@@ -189,6 +189,12 @@ If the flow of screens needs to change, the change can be made easily in one pla
 This library uses [FlowStacks](https://github.com/johnpatrickmorgan/FlowStacks) for hoisting navigation state out of individual screens. FlowStacks can also be used in SwiftUI projects that do not use the Composable Architecture.
 
 
-## Migrating from v0.8 and lower
+## Migrating from earlier versions
+
+### From v0.8 and lower
 
 There has been an API change from v0.8 to v0.9, to bring the library's APIs more in-line with the Composable Architecture, including the use of case paths. If you're migrating to these new APIs please see the [migration docs](Docs/Migration/Migrating%20from%200.8.md).
+
+### From v0.11 and lower
+
+v0.12 introduced a requirement that the screen reducer's state conform to `Hashable`: see the [migration docs](Docs/Migration/Migrating%20from%200.11.md).

--- a/Sources/TCACoordinators/TCARouter/TCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/TCARouter.swift
@@ -24,21 +24,17 @@ public struct TCARouter<
     self.screenContent = screenContent
   }
 
-  func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
-    var screen = screen
-    let id = identifier(screen, index)
-    return store.scope(
-      id: store.id(state: \.[index], action: \.[id: id]),
-      state: ToState {
-        screen = $0[safe: index]?.screen ?? screen
-        return screen
-      },
-      action: {
-        .routeAction(id: id, action: $0)
-      },
-      isInvalid: { !$0.indices.contains(index) }
-    )
-  }
+	func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
+		let routesStore = store
+
+		return routesStore.scope(
+			state: {
+				guard $0.indices.contains(index) else { return screen }
+				return $0[index].screen
+			},
+			action: { .routeAction(id: identifier(screen, index), action: $0) }
+		)
+	}
 
   public var body: some View {
     if Screen.self is ObservableState.Type {

--- a/Sources/TCACoordinators/TCARouter/UnobservedTCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/UnobservedTCARouter.swift
@@ -26,21 +26,17 @@ struct UnobservedTCARouter<
     self.screenContent = screenContent
   }
 
-  func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
-    var screen = screen
-    let id = identifier(screen, index)
-    return store.scope(
-      id: store.id(state: \.[index], action: \.[id: id]),
-      state: ToState {
-        screen = $0[safe: index]?.screen ?? screen
-        return screen
-      },
-      action: {
-        .routeAction(id: id, action: $0)
-      },
-      isInvalid: { !$0.indices.contains(index) }
-    )
-  }
+	func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
+	  let routesStore = store
+
+	  return routesStore.scope(
+		state: {
+		  guard $0.indices.contains(index) else { return screen }
+		  return $0[index].screen
+		},
+		action: { .routeAction(id: identifier(screen, index), action: $0) }
+	  )
+	}
 
   var body: some View {
     WithViewStore(store, observe: { $0 }) { viewStore in

--- a/Sources/TCACoordinators/TCARouter/UnobservedTCARouter.swift
+++ b/Sources/TCACoordinators/TCARouter/UnobservedTCARouter.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// The TCARouter translates that collection into a hierarchy of SwiftUI views, and updates it when the user navigates back.
 /// The unobserved router is used when the Screen does not conform to ObservableState.
 struct UnobservedTCARouter<
-  Screen: Equatable,
+  Screen: Hashable,
   ScreenAction,
   ID: Hashable,
   ScreenContent: View
@@ -26,17 +26,12 @@ struct UnobservedTCARouter<
     self.screenContent = screenContent
   }
 
-	func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
-	  let routesStore = store
-
-	  return routesStore.scope(
-		state: {
-		  guard $0.indices.contains(index) else { return screen }
-		  return $0[index].screen
-		},
-		action: { .routeAction(id: identifier(screen, index), action: $0) }
-	  )
-	}
+  func scopedStore(index: Int, screen: Screen) -> Store<Screen, ScreenAction> {
+    store.scope(
+      state: \.[index, defaultingTo: screen],
+      action: \.[id: identifier(screen, index)]
+    )
+  }
 
   var body: some View {
     WithViewStore(store, observe: { $0 }) { viewStore in

--- a/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TCACoordinatorsExample/TCACoordinatorsExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "76c4411e02cc7768a3f27ca058bd2143c342e5b2",
-        "version" : "1.18.0"
+        "revision" : "294ac2cbfe48a41a6bd3c294fbb7bc5f0f5194d6",
+        "version" : "1.20.1"
       }
     },
     {

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/FinalScreen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/FinalScreen.swift
@@ -95,7 +95,7 @@ struct APIModel: Codable, Equatable {
 @Reducer
 struct FinalScreen {
   @ObservableState
-  struct State: Equatable {
+  struct State: Hashable {
     let firstName: String
     let lastName: String
     let dateOfBirth: Date

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormScreen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormScreen.swift
@@ -21,7 +21,7 @@ struct FormScreenEnvironment: DependencyKey {
   )
 }
 
-@Reducer(state: .equatable)
+@Reducer(state: .equatable, .hashable)
 enum FormScreen {
   case step1(Step1)
   case step2(Step2)

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step1.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step1.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @Reducer
 struct Step1 {
   @ObservableState
-  public struct State: Equatable {
+  public struct State: Hashable {
     var firstName: String = ""
     var lastName: String = ""
   }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step2.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step2.swift
@@ -31,7 +31,7 @@ struct Step2View: View {
 @Reducer
 struct Step2 {
   @ObservableState
-  public struct State: Equatable {
+  public struct State: Hashable {
     var dateOfBirth: Date = .now
   }
 

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step3.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/Step3.swift
@@ -50,7 +50,7 @@ struct Step3View: View {
 @Reducer
 struct Step3 {
   @ObservableState
-  struct State: Equatable {
+  struct State: Hashable {
     var selectedOccupation: String?
     var occupations: [String] = []
   }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameCoordinator.swift
@@ -17,7 +17,7 @@ struct GameCoordinatorView: View {
   }
 }
 
-@Reducer(state: .equatable)
+@Reducer(state: .equatable, .hashable)
 enum GameScreen {
   case game(Game)
   case outcome(Outcome)

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameView.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameView.swift
@@ -164,7 +164,7 @@ final class GameViewController: UIViewController {
 @Reducer
 struct Game {
   @ObservableState
-  struct State: Equatable {
+  struct State: Hashable {
     let id = UUID()
     var board: Three<Three<Player?>> = .empty
     var currentPlayer: Player = .x

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 import TCACoordinators
 
-@Reducer(state: .equatable)
+@Reducer(state: .equatable, .hashable)
 enum LogInScreen {
   case welcome(Welcome)
   case logIn(LogIn)

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInView.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInView.swift
@@ -22,7 +22,7 @@ struct LogInView: View {
 
 @Reducer
 struct LogIn {
-  struct State: Equatable {
+  struct State: Hashable {
     let id = UUID()
   }
 

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/OutcomeView.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/OutcomeView.swift
@@ -27,7 +27,7 @@ struct OutcomeView: View {
 @Reducer
 struct Outcome {
   @ObservableState
-  struct State: Equatable {
+  struct State: Hashable {
     let id = UUID()
     var winner: Player?
     var oPlayerName: String

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/WelcomeView.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/WelcomeView.swift
@@ -18,7 +18,7 @@ struct WelcomeView: View {
 
 @Reducer
 struct Welcome {
-  struct State: Equatable {
+  struct State: Hashable {
     let id = UUID()
   }
 

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Foundation
 import SwiftUI
 
-@Reducer(state: .equatable)
+@Reducer(state: .equatable, .hashable)
 enum Screen {
   case home(Home)
   case numbersList(NumbersList)
@@ -26,7 +26,7 @@ struct HomeView: View {
 
 @Reducer
 struct Home {
-  struct State: Equatable {
+  struct State: Hashable {
     let id = UUID()
   }
 
@@ -58,7 +58,7 @@ struct NumbersListView: View {
 @Reducer
 struct NumbersList {
   @ObservableState
-  struct State: Equatable {
+  struct State: Hashable {
     let id = UUID()
     let numbers: [Int]
   }
@@ -104,7 +104,7 @@ struct NumberDetailView: View {
 @Reducer
 struct NumberDetail {
   @ObservableState
-  struct State: Equatable {
+  struct State: Hashable {
     let id = UUID()
     var number: Int
   }


### PR DESCRIPTION
This PR:

- Builds on a contribution from @iamGus (#80) to ensure the library supports TCA version 1.19.1. The previous way of scoping the Router's store used an internal API that is no longer available.
