### PR TITLE
Remove deprecated @Reducer usage in state management

### DIFF
--- a/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormScreen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Form/FormScreen.swift
@@ -21,10 +21,12 @@ struct FormScreenEnvironment: DependencyKey, Sendable {
   )
 }
 
-@Reducer(state: .equatable, .hashable)
+@Reducer
 enum FormScreen {
   case step1(Step1)
   case step2(Step2)
   case step3(Step3)
   case finalScreen(FinalScreen)
 }
+
+extension FormScreen.State: Hashable { }

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/GameCoordinator.swift
@@ -17,11 +17,13 @@ struct GameCoordinatorView: View {
   }
 }
 
-@Reducer(state: .equatable, .hashable)
+@Reducer
 enum GameScreen {
   case game(Game)
   case outcome(Outcome)
 }
+
+extension GameScreen.State: Hashable { }
 
 @Reducer
 struct GameCoordinator {

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Game/LogInCoordinator.swift
@@ -2,11 +2,13 @@ import ComposableArchitecture
 import SwiftUI
 import TCACoordinators
 
-@Reducer(state: .equatable, .hashable)
+@Reducer
 enum LogInScreen {
   case welcome(Welcome)
   case logIn(LogIn)
 }
+
+extension LogInScreen.State: Hashable { }
 
 struct LogInCoordinatorView: View {
   let store: StoreOf<LogInCoordinator>

--- a/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
+++ b/TCACoordinatorsExample/TCACoordinatorsExample/Screen.swift
@@ -2,12 +2,14 @@ import ComposableArchitecture
 import Foundation
 import SwiftUI
 
-@Reducer(state: .equatable, .hashable)
+@Reducer
 enum Screen {
   case home(Home)
   case numbersList(NumbersList)
   case numberDetail(NumberDetail)
 }
+
+extension Screen.State: Hashable { }
 
 // Home
 


### PR DESCRIPTION
Hello.
Thank you for TCACoordinators.
I found some warnings in the project and fixed the ones related to deprecated `@Reducer` usage.